### PR TITLE
ignore pos of some events

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -123,7 +123,7 @@ class BinLogStreamReader(object):
             if binlog_event.event_type == ROTATE_EVENT:
                 self.log_pos = binlog_event.event.position
                 self.log_file = binlog_event.event.next_binlog
-            else:
+            elif binlog_event.log_pos:
                 self.log_pos = binlog_event.log_pos
 
             if self.__filter_event(binlog_event.event):


### PR DESCRIPTION
refer to #29

log_pos of some events are just not useful and should no be logged.

I'm not familiar of all the mysql binlog events, so I just chosen some events as demo.
