### PR TITLE
Return if the stream is nonblocking

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -111,10 +111,10 @@ class BinLogStreamReader(object):
                     self.__connected_stream = False
                     continue
 
-            if not pkt.is_ok_packet():
-                if not self.__blocking:
-                    return None
+            if pkt.is_eof_packet():
+                return None
 
+            if not pkt.is_ok_packet():
                 continue
 
             binlog_event = BinLogPacketWrapper(pkt, self.table_map,


### PR DESCRIPTION
If the stream is nonblocking we actually get this invalid packet and
should just stop.

@noplay you introduced the new behaviour. I think we need to stop the stream if we got such an packet. What do you think? This could have also caused the problem you had with your tests?
