### PR TITLE
use NotImplementedEvent instead of raising an Exception

### DIFF
--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -81,14 +81,8 @@ class BinLogPacketWrapper(object):
         else:
             event_size_without_header = self.event_size - 19
 
-
-        try:
-            event_class = self.__event_map[self.event_type]
-        except KeyError:
-            raise NotImplementedError(
-                "Unknown MySQL bin log event type: %s (%s)" %
-                (hex(self.event_type), self.event_type))
-
+        event_class = self.__event_map.get(self.event_type,
+            event.NotImplementedEvent)
         self.event = event_class(self, event_size_without_header, table_map,
                                  ctl_connection)
 


### PR DESCRIPTION
using NotImplementedEvent instead of raising an Exception which leads to a main loop break.
Also one can get the position of the next event if he want to skip the known event which could not achived by raising an Exception.
