### PR TITLE
fix pymysql version compare bug

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -114,7 +114,7 @@ class BinLogStreamReader(object):
         prelude += struct.pack('<I', self.__server_id)
         prelude += self.log_file.encode()
 
-        if pymysql.VERSION < (0, 6, None):
+        if pymysql.__version__ < "0.6":
             self._stream_connection.wfile.write(prelude)
             self._stream_connection.wfile.flush()
         else:
@@ -130,7 +130,7 @@ class BinLogStreamReader(object):
                 self.__connect_to_ctl()
 
             try:
-                if pymysql.VERSION < (0, 6, None):
+                if pymysql.__version__ < "0.6":
                     pkt = self._stream_connection.read_packet()
                 else:
                     pkt = self._stream_connection._read_packet()


### PR DESCRIPTION
`VERSION` in lasted pymysql is `(0, 6, 1, None)` and the old versions has something like `(0, x, None)` .
So there is a bug when compare to `(0, 6, None)` in **py3k**. This pr fixed this bug. 
