### PR TITLE
remove bool conversion

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -62,9 +62,6 @@ class RowsEvent(BinLogEvent):
                     values[name] = struct.unpack("<B", self.packet.read(1))[0]
                 else:
                     values[name] = struct.unpack("<b", self.packet.read(1))[0]
-
-                if column.type_is_bool:
-                    values[name] = bool(values[name])
             elif column.type == FIELD_TYPE.SHORT:
                 if unsigned:
                     values[name] = struct.unpack("<H", self.packet.read(2))[0]


### PR DESCRIPTION
as discussed in #16

The `bool` useage is unlikely to be broken since `if some_col_value` equals `if bool(some_col_value)`, but it exposes the raw data from mysql, which is more suitable for a replication lib.
