### PR TITLE
IndexError in TableMapEvent

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -494,7 +494,7 @@ class TableMapEvent(BinLogEvent):
         # Read columns meta data
         column_types = list(self.packet.read(self.column_count))
         self.packet.read_length_coded_binary()
-        for i in range(0, len(column_types)):
+        for i in range(0, min(len(column_types), len(self.column_schemas))):
             column_type = column_types[i]
             column_schema = self.column_schemas[i]
             col = Column(byte2int(column_type), column_schema, from_packet)


### PR DESCRIPTION
``` py
Traceback (most recent call last):
  File "/usr/local/opt/pyenv/versions/py3@meepo/bin/mprint", line 9, in <module>
    load_entry_point('meepo==0.1.0', 'console_scripts', 'mprint')()
  File "/usr/local/var/lib/pyenv/versions/py3@meepo/lib/python3.4/site-packages/click/core.py", line 488, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/var/lib/pyenv/versions/py3@meepo/lib/python3.4/site-packages/click/core.py", line 474, in main
    self.invoke(ctx)
  File "/usr/local/var/lib/pyenv/versions/py3@meepo/lib/python3.4/site-packages/click/core.py", line 659, in invoke
    ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/var/lib/pyenv/versions/py3@meepo/lib/python3.4/site-packages/click/core.py", line 325, in invoke
    return callback(*args, **kwargs)
  File "/Users/lxyu/Workspace/eleme/meepo/meepo/apps/mprint.py", line 24, in main
    mysql_pub(mysql_dsn)
  File "/Users/lxyu/Workspace/eleme/meepo/meepo/pub.py", line 50, in mysql_pub
    for event in stream:
  File "/Users/lxyu/Workspace/lxyu/python-mysql-replication/pymysqlreplication/binlogstream.py", line 155, in fetchone
    self.__use_checksum)
  File "/Users/lxyu/Workspace/lxyu/python-mysql-replication/pymysqlreplication/packet.py", line 85, in __init__
    ctl_connection)
  File "/Users/lxyu/Workspace/lxyu/python-mysql-replication/pymysqlreplication/row_event.py", line 499, in __init__
    column_schema = self.column_schemas[i]
IndexError: list index out of range
```

A print when these 2 list length not equal.

``` py
column_types = [3, 8, 15, 10, 10, 1]
self.column_schemas = [{'CHARACTER_SET_NAME': None,
  'COLLATION_NAME': None,
  'COLUMN_TYPE': 'int(11)',
  'COLUMN_KEY': 'PRI',
  'COLUMN_NAME': 'id',
  'COLUMN_COMMENT': ''},
 {'CHARACTER_SET_NAME': None,
  'COLLATION_NAME': None,
  'COLUMN_TYPE': 'bigint(20) unsigned',
  'COLUMN_KEY': 'MUL',
  'COLUMN_NAME': 'mobile',
  'COLUMN_COMMENT': ''},
 {'CHARACTER_SET_NAME': None,
  'COLLATION_NAME': None,
  'COLUMN_TYPE': 'date',
  'COLUMN_KEY': 'MUL',
  'COLUMN_NAME': 'valid_start',
  'COLUMN_COMMENT': ''},
 {'CHARACTER_SET_NAME': None,
  'COLLATION_NAME': None,
  'COLUMN_TYPE': 'date',
  'COLUMN_KEY': 'MUL',
  'COLUMN_NAME': 'valid_end',
  'COLUMN_COMMENT': ''},
 {'CHARACTER_SET_NAME': None,
  'COLLATION_NAME': None,
  'COLUMN_TYPE': 'tinyint(4)',
  'COLUMN_KEY': 'MUL',
  'COLUMN_NAME': 'is_valid',
  'COLUMN_COMMENT': ''}]
```

I come across this bug sometimes, where the self.column_schemas length is less than column_types.

I just bypass it without further dig into why this happens. You may consider this PR a bug report.
