### PR TITLE
Use a simplifed  byte2int

### DIFF
--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -3,7 +3,7 @@
 import struct
 import datetime
 
-from pymysql.util import byte2int, int2byte
+from .util import byte2int, int2byte
 
 
 class BinLogEvent(object):

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -2,9 +2,9 @@
 
 import struct
 
-from pymysql.util import byte2int
 
 from pymysqlreplication import constants, event, row_event
+from .util import byte2int
 
 # Constants from PyMYSQL source code
 NULL_COLUMN = 251

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -496,7 +496,7 @@ class TableMapEvent(BinLogEvent):
         for i in range(0, len(column_types)):
             column_type = column_types[i]
             column_schema = self.column_schemas[i]
-            col = Column(column_type, column_schema, from_packet)
+            col = Column(byte2int(column_type), column_schema, from_packet)
             self.columns.append(col)
 
         self.table_obj = Table(self.column_schemas, self.table_id, self.schema,

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -4,8 +4,7 @@ import struct
 import decimal
 import datetime
 
-from pymysql.util import byte2int
-
+from .util import byte2int
 from .event import BinLogEvent
 from .constants import FIELD_TYPE
 from .constants import BINLOG
@@ -497,7 +496,7 @@ class TableMapEvent(BinLogEvent):
         for i in range(0, len(column_types)):
             column_type = column_types[i]
             column_schema = self.column_schemas[i]
-            col = Column(byte2int(column_type), column_schema, from_packet)
+            col = Column(column_type, column_schema, from_packet)
             self.columns.append(col)
 
         self.table_obj = Table(self.column_schemas, self.table_id, self.schema,

--- a/pymysqlreplication/util.py
+++ b/pymysqlreplication/util.py
@@ -1,0 +1,7 @@
+import struct
+
+def byte2int(b):
+    return struct.unpack("!B", b)[0]
+
+def int2byte(i):
+    return struct.pack("!B", i)

--- a/pymysqlreplication/util.py
+++ b/pymysqlreplication/util.py
@@ -1,7 +1,10 @@
 import struct
 
 def byte2int(b):
-    return struct.unpack("!B", b)[0]
+    try:
+        return struct.unpack("!B", b)[0]
+    except TypeError: #With python 3 some read return int
+        return b
 
 def int2byte(i):
     return struct.pack("!B", i)


### PR DESCRIPTION
It's offer a very small performance gain

The original implementation from PyMySQL test instance type
before.
https://github.com/PyMySQL/PyMySQL/blob/3be54819ee6b09710be892a2b86f4592eaabf412/pymysql/util.py

It's not require and by dropping it's a little faster.
