### PR TITLE
Freeze table map event

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -31,7 +31,8 @@ class BinLogStreamReader(object):
                  blocking=False, only_events=None, log_file=None, log_pos=None,
                  filter_non_implemented_events=True,
                  ignored_events=None, auto_position=None,
-                 only_tables = None, only_schemas = None):
+                 only_tables = None, only_schemas = None,
+                 freeze_schema = False):
         """
         Attributes:
             resume_stream: Start for event from position or the latest event of
@@ -44,6 +45,7 @@ class BinLogStreamReader(object):
             auto_position: Use master_auto_position gtid to set position
             only_tables: An array with the tables you want to watch
             only_schemas: An array with the schemas you want to watch
+            freeze_schema: If true do not support ALTER TABLE. It's faster. (default False)
         """
         self.__connection_settings = connection_settings
         self.__connection_settings["charset"] = "utf8"
@@ -55,6 +57,7 @@ class BinLogStreamReader(object):
 
         self.__only_tables = only_tables
         self.__only_schemas = only_schemas
+        self.__freeze_schema = freeze_schema
         self.__allowed_events = self._allowed_event_list(only_events, ignored_events, filter_non_implemented_events)
 
         # We can't filter on packet level TABLE_MAP and rotate event because we need
@@ -241,7 +244,8 @@ class BinLogStreamReader(object):
                                                self.__use_checksum,
                                                self.__allowed_events_in_packet,
                                                self.__only_tables,
-                                               self.__only_schemas)
+                                               self.__only_schemas,
+                                               self.__freeze_schema)
 
             if binlog_event.event_type == TABLE_MAP_EVENT and binlog_event.event is not None:
                 self.table_map[binlog_event.event.table_id] = \

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -9,7 +9,8 @@ from pymysql.util import byte2int, int2byte
 class BinLogEvent(object):
     def __init__(self, from_packet, event_size, table_map, ctl_connection,
                  only_tables = None,
-                 only_schemas = None):
+                 only_schemas = None,
+                 freeze_schema = False):
         self.packet = from_packet
         self.table_map = table_map
         self.event_type = self.packet.event_type

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -51,7 +51,8 @@ class BinLogPacketWrapper(object):
     def __init__(self, from_packet, table_map, ctl_connection, use_checksum,
                  allowed_events,
                  only_tables,
-                 only_schemas):
+                 only_schemas,
+                 freeze_schema):
         # -1 because we ignore the ok byte
         self.read_bytes = 0
         # Used when we want to override a value in the data buffer
@@ -91,7 +92,8 @@ class BinLogPacketWrapper(object):
         self.event = event_class(self, event_size_without_header, table_map,
                                  ctl_connection,
                                  only_tables = only_tables,
-                                 only_schemas = only_schemas)
+                                 only_schemas = only_schemas,
+                                 freeze_schema = freeze_schema)
         if self.event._processed == False:
             self.event = None
 

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -490,11 +490,12 @@ class TableMapEvent(BinLogEvent):
                                             table_map, ctl_connection, **kwargs)
         self.__only_tables = kwargs["only_tables"]
         self.__only_schemas = kwargs["only_schemas"]
+        self.__freeze_schema = kwargs["freeze_schema"]
 
         # Post-Header
         self.table_id = self._read_table_id()
 
-        if self.table_id in table_map:
+        if self.table_id in table_map and self.__freeze_schema:
             self._processed = False
             return
 


### PR DESCRIPTION
By not supporting alter table we can get huge performance gains.
The reason is we can skip parsing TableMapEvent

It's an optional parameter.
