### PR TITLE
Full handling of bin log checksums

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -274,10 +274,8 @@ class BinLogStreamReader(object):
         # we support it
         if self.__use_checksum:
             cur = self._stream_connection.cursor()
-            # sagi's fix
-            # cur.execute("set @master_binlog_checksum= @@global.binlog_checksum")            
             # if checksum is enabled on server - 
-            # turn it off at current session for getting rotate events always 
+            # turn it off at the current session for getting rotate events always
             # without checksum
             cur.execute("set @master_binlog_checksum= 'NONE'")
             cur.close()
@@ -431,18 +429,15 @@ class BinLogStreamReader(object):
             if not pkt.is_ok_packet():
                 continue
 
-            #sagi's fix
-
             if 'stream_has_checksum' in dir(self):
                 # use checksum from stream
                 checksum_to_use = self.stream_has_checksum
             else:
                 # use checksum from server
-                checksum_to_use = False #self.__use_checksum
+                checksum_to_use = False
 
             binlog_event = BinLogPacketWrapper(pkt, self.table_map,
                                                self._ctl_connection,
-                                               #self.__use_checksum,
                                                checksum_to_use,
                                                self.__allowed_events_in_packet,
                                                self.__only_tables,
@@ -451,14 +446,12 @@ class BinLogStreamReader(object):
                                                self.__ignored_schemas,
                                                self.__freeze_schema,
                                                self.__fail_on_table_metadata_unavailable)
-            #sagi's fix
-            # if FORMAT_DESCRIPTION event has checksum - 
+            # if FORMAT_DESCRIPTION event has checksum -
             # means hole file includes checksum
             if binlog_event.event_type == FORMAT_DESCRIPTION_EVENT:
                 self.stream_has_checksum = binlog_event.event.has_checksum
 
             if binlog_event.event_type == ROTATE_EVENT:
-                # sagi's fix
                 # increment file if the new file is actually the next one and
                 # it isn't fake rotate
                 if self.log_file < binlog_event.event.next_binlog:

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -446,9 +446,10 @@ class BinLogStreamReader(object):
                                                self.__ignored_schemas,
                                                self.__freeze_schema,
                                                self.__fail_on_table_metadata_unavailable)
-            # if FORMAT_DESCRIPTION event has checksum -
-            # means hole file includes checksum
+
             if binlog_event.event_type == FORMAT_DESCRIPTION_EVENT:
+                # if FORMAT_DESCRIPTION event has checksum -
+                # means hole file includes checksum
                 self.stream_has_checksum = binlog_event.event.has_checksum
 
             if binlog_event.event_type == ROTATE_EVENT:

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -187,10 +187,10 @@ class BinLogStreamReader(object):
             only_events, ignored_events, filter_non_implemented_events)
         self.__fail_on_table_metadata_unavailable = fail_on_table_metadata_unavailable
 
-        # We can't filter on packet level TABLE_MAP and rotate event because
-        # we need them for handling other operations
+        # We can't filter on packet level TABLE_MAP, rotate event and
+        # format description event because we need them for handling other operations
         self.__allowed_events_in_packet = frozenset(
-            [TableMapEvent, RotateEvent]).union(self.__allowed_events)
+            [TableMapEvent, RotateEvent, FormatDescriptionEvent]).union(self.__allowed_events)
 
         self.__server_id = server_id
         self.__server_has_checksum = False

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -92,8 +92,8 @@ class RotateEvent(BinLogEvent):
         self.position = struct.unpack('<Q', self.packet.read(8))[0]
         rest_of_event_data = self.packet.read(event_size - 8)
         try:
-            self.next_binlog = re.findall('.+\.\d+', rest_of_event_data)[0]
-
+            self.next_binlog = re.findall(b'.+\.\d+', rest_of_event_data)[0]
+            # TODO: sometimes got: TypeError: cannot use a string pattern on a bytes-like object
         except IndexError:  # We failed to parse the next binlog file name
             self.next_binlog = None
 

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -93,7 +93,7 @@ class RotateEvent(BinLogEvent):
         rest_of_event_data = self.packet.read(event_size - 8)
         try:
             self.next_binlog = re.findall(b'.+\.\d+', rest_of_event_data)[0]
-            # TODO: sometimes got: TypeError: cannot use a string pattern on a bytes-like object
+            
         except IndexError:  # We failed to parse the next binlog file name
             self.next_binlog = None
 
@@ -109,7 +109,7 @@ class FormatDescriptionEvent(BinLogEvent):
         super(FormatDescriptionEvent, self).__init__(from_packet, event_size, table_map,
                                           ctl_connection, **kwargs)
         self.binlog_version = struct.unpack('<H', self.packet.read(2))[0]
-        self.server_version = self.packet.read(50).rstrip('\x00')
+        self.server_version = self.packet.read(50).rstrip(b'\x00')
         self.has_checksum = False
         if "5.6.1" <= self.server_version or \
                 (("mariadb" in self.server_version) and ("5.3" <= self.server_version)):

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -90,7 +90,6 @@ class RotateEvent(BinLogEvent):
         super(RotateEvent, self).__init__(from_packet, event_size, table_map,
                                           ctl_connection, **kwargs)
         self.position = struct.unpack('<Q', self.packet.read(8))[0]
-        # Sagi's fix
         rest_of_event_data = self.packet.read(event_size - 8)
         try:
             self.next_binlog = rest_of_event_data.decode()
@@ -106,7 +105,6 @@ class RotateEvent(BinLogEvent):
 
 
 class FormatDescriptionEvent(BinLogEvent):
-    #sagi's fix
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
         super(FormatDescriptionEvent, self).__init__(from_packet, event_size, table_map,
                                           ctl_connection, **kwargs)

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -108,7 +108,7 @@ class FormatDescriptionEvent(BinLogEvent):
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
         super(FormatDescriptionEvent, self).__init__(from_packet, event_size, table_map,
                                           ctl_connection, **kwargs)
-        self.binlog_version = struct.unpack('<H', self.packet.read(2))[0].decode()
+        self.binlog_version = struct.unpack('<H', self.packet.read(2))[0]
         self.server_version = self.packet.read(50).rstrip(b'\x00').decode()
         self.has_checksum = False
         if "5.6.1" <= self.server_version or \

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -92,8 +92,8 @@ class RotateEvent(BinLogEvent):
         self.position = struct.unpack('<Q', self.packet.read(8))[0]
         rest_of_event_data = self.packet.read(event_size - 8)
         try:
-            self.next_binlog = re.findall(b'.+\.\d+', rest_of_event_data)[0]
-            
+            self.next_binlog = re.findall(b'.+\.\d+', rest_of_event_data)[0].decode()
+
         except IndexError:  # We failed to parse the next binlog file name
             self.next_binlog = None
 
@@ -108,8 +108,8 @@ class FormatDescriptionEvent(BinLogEvent):
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
         super(FormatDescriptionEvent, self).__init__(from_packet, event_size, table_map,
                                           ctl_connection, **kwargs)
-        self.binlog_version = struct.unpack('<H', self.packet.read(2))[0]
-        self.server_version = self.packet.read(50).rstrip(b'\x00')
+        self.binlog_version = struct.unpack('<H', self.packet.read(2))[0].decode()
+        self.server_version = self.packet.read(50).rstrip(b'\x00').decode()
         self.has_checksum = False
         if "5.6.1" <= self.server_version or \
                 (("mariadb" in self.server_version) and ("5.3" <= self.server_version)):

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -122,18 +122,12 @@ class FormatDescriptionEvent(BinLogEvent):
             if struct.unpack('b', self.packet.read(1))[0] == 1:
                 self.has_checksum = True
             # 4 remaining bytes - checksum itself
-        else:
-            self.has_checksum = False
-
-
 
     def dump(self):
         print("=== %s ===" % (self.__class__.__name__))
         print("Binlog Version: %s" % self.binlog_version)
         print("Server Version: %s" % self.server_version)
         print()
-
-    #pass
 
 
 class StopEvent(BinLogEvent):

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -119,8 +119,7 @@ class BinLogPacketWrapper(object):
         self.flags = unpack[6]
 
         # MySQL 5.6 and more if binlog-checksum = CRC32
-        #sagi's fix
-        #event_size_without_header = self.event_size - 19
+
         if use_checksum:
             event_size_without_header = self.event_size - 23
         else:

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -118,8 +118,7 @@ class BinLogPacketWrapper(object):
         self.log_pos = unpack[5]
         self.flags = unpack[6]
 
-        # MySQL 5.6 and more if binlog-checksum = CRC32
-
+        # MySQL 5.6 and more if binlog file contains checksum
         if use_checksum:
             event_size_without_header = self.event_size - 23
         else:

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -119,6 +119,8 @@ class BinLogPacketWrapper(object):
         self.flags = unpack[6]
 
         # MySQL 5.6 and more if binlog-checksum = CRC32
+        #sagi's fix
+        #event_size_without_header = self.event_size - 19
         if use_checksum:
             event_size_without_header = self.event_size - 23
         else:

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -23,9 +23,9 @@ class PyMySQLReplicationTestCase(base):
         db = os.environ.get('DB')
         # default
         self.database = {
-            "host": "localhost",
+            "host": "sagi-i.alooma-dev.com",#""localhost",
             "user": "root",
-            "passwd": "",
+            "passwd": "pass",#""",
             "port": 3306,
             "use_unicode": True,
             "charset": "utf8",

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -23,9 +23,9 @@ class PyMySQLReplicationTestCase(base):
         db = os.environ.get('DB')
         # default
         self.database = {
-            "host": "sagi-i.alooma-dev.com",#""localhost",
+            "host": "localhost",
             "user": "root",
-            "passwd": "pass",#""",
+            "passwd": "",
             "port": 3306,
             "use_unicode": True,
             "charset": "utf8",


### PR DESCRIPTION
Following the error (#260 ), we looked into checksum handling in some other binlog reading libraries. Eventually we found this [commit](https://github.com/shyiko/mysql-binlog-connector-java/commit/1f4fe856b4a0274a8946734f130ef146462fb493) in shyiko’s mysql-binlog-connector-java repository, which seems to handle this issue.

The high-level solution here is disabling the checksum when we create a session with the db, so that all rotate events are sent from the server without a checksum. That way we can always read the next binlog file from server-auto-generated rotate events.

To handle the rotate events in the files themselves (which could have been written with a checksum even if checksum is now disabled on the server), we deduce the checksum status for each file based on the FormatDescriptionEvent in the beginning of the file instead of relying on the current server config.