### PR TITLE
Parse NULL-bitmask in table map event

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -648,8 +648,9 @@ class TableMapEvent(BinLogEvent):
         self.table_obj = Table(self.column_schemas, self.table_id, self.schema,
                                self.table, self.columns)
 
-        # TODO: get this information instead of trashing data
-        # n              NULL-bitmask, length: (column-length * 8) / 7
+        # ith column is nullable if (i - 1)th bit is set to True, not nullable otherwise
+        ## Refer to definition of and call to row.event.__is_null() to interpret bitmap corresponding to columns
+        self.null_bitmask = self.packet.read((self.column_count + 7) / 8)
 
     def get_table(self):
         return self.table_obj


### PR DESCRIPTION
This PR adds null-bitmask attribute to table map event.
The attribute is a bit mask where  _(i - 1)_ th bit is set if _i_ th column is nullable.
Added and passed relevant tests.

This feature is suggested in the following comments:
https://github.com/noplay/python-mysql-replication/blob/f70f05bc143bbf50dad5461dcb3a2a47a7f67202/pymysqlreplication/row_event.py#L651-L652

# References
## [MySQL Documentation](https://dev.mysql.com/doc/)
* [Fields in table map event](https://dev.mysql.com/doc/internals/en/table-map-event.html)
## [mysql-server source code](https://github.com/mysql/mysql-server)
* [buffer layout for table map event](https://github.com/mysql/mysql-server/blob/beb865a960b9a8a16cf999c323e46c5b0c67f21f/libbinlogevents/include/rows_event.h#L633-L639)
* [null bitmask in mysql-server](https://github.com/mysql/mysql-server/blob/beb865a960b9a8a16cf999c323e46c5b0c67f21f/libbinlogevents/src/rows_event.cpp#L93)