### PR TITLE
Skip db name parsing if mts_accessed_dbs == 254

### DIFF
--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -257,6 +257,17 @@ class QueryEvent(BinLogEvent):
                 self.host = self.packet.read(host_len)
         elif key == Q_UPDATED_DB_NAMES:               # 0x0C
             mts_accessed_dbs = self.packet.read_uint8()
+            """
+            mts_accessed_dbs < 254:
+                `mts_accessed_dbs` is equal to the number of dbs
+                acessed by the query event.
+            mts_accessed_dbs == 254:
+                This is the case where the number of dbs accessed
+                is 1 and the name of the only db is ""
+                Since no further parsing required(empty name), return.
+            """
+            if mts_accessed_dbs == 254:
+                return
             dbs = []
             for i in range(mts_accessed_dbs):
                 db = self.packet.read_string()


### PR DESCRIPTION
This PR is a fix for [PR#360](https://github.com/noplay/python-mysql-replication/pull/360)(released in 0.27)

I interpreted `mts_accessed_dbs` as db count in [PR#360](https://github.com/noplay/python-mysql-replication/pull/360) .
However after reproducing kvitek's crash in [Issue#278](https://github.com/noplay/python-mysql-replication/issues/278#issuecomment-1060897201),
I did some more research how the variable is set:

https://github.com/mysql/mysql-server/blob/6846e6b2f72931991cc9fd589dc9946ea2ab58c9/sql/log_event.cc#L3598-L3602



(log_event.h /log_event.cc is responsible for writing low-level binlog,
according to
https://dev.mysql.com/doc/internals/en/source-files-related-to-the-binary-log.html)

Turns out that if the value of the variables equals 254,
the variable is no longer interpreted as the db count,
but represent a following case:
1. db count equals 1
2. The name of the only db is ""(blank).

Therefore, I edited event.py so that after the value 254 is encountered,
no further parsing is done regarding db names. ("" doesn't need to be parsed)

So far I have reproduced the issue for `BeginEvent`.
However, I have not yet figured out to incorporate into unittest.
I will add tests ASAP.