### PR TITLE
Fix test_allowed_event_list, MariadbGtidEvent added

### DIFF
--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -25,9 +25,9 @@ class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
         return [GtidEvent]
 
     def test_allowed_event_list(self):
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 14)
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 13)
-        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 13)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 15)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 14)
+        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 14)
         self.assertEqual(len(self.stream._allowed_event_list([RotateEvent], None, False)), 1)
 
     def test_read_query_event(self):


### PR DESCRIPTION
Currently the `TestBasicBinLogStreamReader::test_allowed_event_list` test fails,
with the actual number being one more than the expected number.

The reason for that is the recent addition of `MariadbGtidEvent` commit
7fd706d1686da90cdb3991279c764f057e24a1f6.

This commit adapts the expected numbers in the test to reflect that change.