### PR TITLE
Fix RowsEvent.__is_null usage in tests

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -85,7 +85,8 @@ class RowsEvent(BinLogEvent):
             if self._fail_on_table_metadata_unavailable:
                 raise TableMetadataUnavailableError(self.table)
 
-    def __is_null(self, null_bitmap, position):
+    @staticmethod
+    def _is_null(null_bitmap, position):
         bit = null_bitmap[int(position / 8)]
         if type(bit) is str:
             bit = ord(bit)
@@ -113,7 +114,7 @@ class RowsEvent(BinLogEvent):
                 values[name] = None
                 continue
 
-            if self.__is_null(null_bitmap, nullBitmapIndex):
+            if self._is_null(null_bitmap, nullBitmapIndex):
                 values[name] = None
             elif column.type == FIELD_TYPE.TINY:
                 if unsigned:
@@ -649,7 +650,7 @@ class TableMapEvent(BinLogEvent):
                                self.table, self.columns)
 
         # ith column is nullable if (i - 1)th bit is set to True, not nullable otherwise
-        ## Refer to definition of and call to row.event.__is_null() to interpret bitmap corresponding to columns
+        ## Refer to definition of and call to row.event._is_null() to interpret bitmap corresponding to columns
         self.null_bitmask = self.packet.read((self.column_count + 7) / 8)
 
     def get_table(self):

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -730,7 +730,7 @@ class TestDataType(base.PyMySQLReplicationTestCase):
             column_type = "INT"
             column_definition.append(column_type)
 
-            nullability = "NOT NULL" if not RowsEvent.__is_null(bit_mask, i) else ""
+            nullability = "NOT NULL" if not RowsEvent._is_null(bit_mask, i) else ""
             column_definition.append(nullability)
 
             columns.append(" ".join(column_definition))


### PR DESCRIPTION
The test `TestDataType::test_null_bitmask` currently fails with
```
AttributeError: type object 'RowsEvent' has no attribute '_TestDataType__is_null'`
```

The test method in the `TestDataType` class calls the `__is_null` method of the
`RowsEvent` class. Due to name mangling of "private" methods/variables in
Python [1] the calling class name is prepended to the method name. This makes
the call fail when called from a foreign class.

This commit fixes that by
a) Renaming `__is_null` to `_is_null` which is only "private" by convention and
   involves no name mangling.
b) Makes the method a staticmethod, as it's not depending on any instances or
   class attributes/ methods, and is referenced by class only (and not by
   instance) in the test.

[1] https://docs.python.org/3/tutorial/classes.html#private-variables