### PR TITLE
Fix decoding large json arrays

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,5 @@
 name: PyTest
-on: push
+on: [push, pull_request]
 
 jobs:
   test:

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -402,9 +402,9 @@ class BinLogPacketWrapper(object):
         elif t == JSONB_TYPE_UINT16:
             return self.read_uint32() if large else self.read_uint16()
         elif t == JSONB_TYPE_INT32:
-            return self.read_int64() if large else self.read_int32()
+            return self.read_int32()
         elif t == JSONB_TYPE_UINT32:
-            return self.read_uint64() if large else self.read_uint32()
+            return self.read_uint32()
 
         raise ValueError('Json type %d is not handled' % t)
 

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -513,6 +513,16 @@ class TestDataType(base.PyMySQLReplicationTestCase):
 
         self.assertEqual(event.rows[0]["values"]["value"], to_binary_dict(data))
 
+    def test_json_large_array(self):
+        "Test json array larger than 64k bytes"
+        if not self.isMySQL57():
+            self.skipTest("Json is only supported in mysql 5.7")
+        create_query = "CREATE TABLE test (id int, value json);"
+        large_array = dict(my_key=[i for i in range(100000)])
+        insert_query = "INSERT INTO test (id, value) VALUES (1, '%s');" % (json.dumps(large_array),)
+        event = self.create_and_insert_value(create_query, insert_query)
+        self.assertEqual(event.rows[0]["values"]["value"], to_binary_dict(large_array))
+
     def test_json_large_with_literal(self):
         if not self.isMySQL57():
             self.skipTest("Json is only supported in mysql 5.7")


### PR DESCRIPTION
Without the fix, the included test fails with

```
AssertionError: Result length not requested length:
Expected=2.  Actual=0.  Position: 500079.  Data Length: 500079
```
But I suspect (and have seen) also other errors, depending on specific contents
of the byte stream, e.g. ("Json type $random is not handled").

Int32/UInt32 values in json arrays are encoded inline in the "large" encoding
mode, but they are stored using 4 bytes, not 8.  So the `read_uint64()` calls
are wrong here, `read_uint32()` works. Also the check for `large` in that case
is redundant, as `large` is always True for inlined int32/uint32 values.

Relevant parts in mysql server code are functions `serialize_json_array`,
`should_inline_value` and `insert_offset_or_size` in `sql/json_binary.cc` [1].

I believe this fixes issue #311.

[1] https://github.com/mysql/mysql-server/blob/5.7/sql/json_binary.cc