### PR TITLE
Run tests with different Python versions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,6 +3,18 @@ on: [push, pull_request]
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {name: 'CPython 3.7', python: '3.7'}
+          - {name: 'CPython 3.8', python: '3.8'}
+          - {name: 'CPython 3.9', python: '3.9'}
+          - {name: 'CPython 3.10', python: '3.10'}
+          - {name: 'Pypy 3.7', python: 'pypy-3.7'}
+          - {name: 'Pypy 3.8', python: 'pypy-3.8'}
+          - {name: 'Pypy 3.9', python: 'pypy-3.9'}
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
 
@@ -13,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ matrix.python }}
 
       - name: Run database server in docker
         run: |


### PR DESCRIPTION
Use a matrix strategy to run the test suite with different Python interpreter
versions.