### PR TITLE
fix: redis cache example

### DIFF
--- a/examples/redis_cache.py
+++ b/examples/redis_cache.py
@@ -28,6 +28,7 @@ def main():
 
     stream = BinLogStreamReader(
         connection_settings=MYSQL_SETTINGS,
+        server_id=3,  # server_id is your slave identifier, it should be unique
         only_events=[DeleteRowsEvent, WriteRowsEvent, UpdateRowsEvent])
 
     for binlogevent in stream:


### PR DESCRIPTION
Fix `TypeError: BinLogStreamReader.__init__() missing 1 required positional argument: 'server_id'` in redid cache example.