### PR TITLE
Add support for ignoring string decode errors

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -140,7 +140,8 @@ class BinLogStreamReader(object):
                  pymysql_wrapper=None,
                  fail_on_table_metadata_unavailable=False,
                  slave_heartbeat=None,
-                 is_mariadb=False):
+                 is_mariadb=False,
+                 ignore_decode_errors=False):
         """
         Attributes:
             ctl_connection_settings: Connection settings for cluster holding
@@ -177,6 +178,8 @@ class BinLogStreamReader(object):
                              for semantics
             is_mariadb: Flag to indicate it's a MariaDB server, used with auto_position
                     to point to Mariadb specific GTID.
+            ignore_decode_errors: If true, any decode errors encountered 
+                                  when reading column data will be ignored.
         """
 
         self.__connection_settings = connection_settings
@@ -198,6 +201,7 @@ class BinLogStreamReader(object):
         self.__allowed_events = self._allowed_event_list(
             only_events, ignored_events, filter_non_implemented_events)
         self.__fail_on_table_metadata_unavailable = fail_on_table_metadata_unavailable
+        self.__ignore_decode_errors = ignore_decode_errors
 
         # We can't filter on packet level TABLE_MAP and rotate event because
         # we need them for handling other operations
@@ -502,7 +506,8 @@ class BinLogStreamReader(object):
                                                self.__only_schemas,
                                                self.__ignored_schemas,
                                                self.__freeze_schema,
-                                               self.__fail_on_table_metadata_unavailable)
+                                               self.__fail_on_table_metadata_unavailable,
+                                               self.__ignore_decode_errors)
 
             if binlog_event.event_type == ROTATE_EVENT:
                 self.log_pos = binlog_event.event.position

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -13,7 +13,8 @@ class BinLogEvent(object):
                  only_schemas=None,
                  ignored_schemas=None,
                  freeze_schema=False,
-                 fail_on_table_metadata_unavailable=False):
+                 fail_on_table_metadata_unavailable=False,
+                 ignore_decode_errors=False):
         self.packet = from_packet
         self.table_map = table_map
         self.event_type = self.packet.event_type
@@ -21,6 +22,7 @@ class BinLogEvent(object):
         self.event_size = event_size
         self._ctl_connection = ctl_connection
         self._fail_on_table_metadata_unavailable = fail_on_table_metadata_unavailable
+        self._ignore_decode_errors = ignore_decode_errors
         # The event have been fully processed, if processed is false
         # the event will be skipped
         self._processed = True

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -96,7 +96,8 @@ class BinLogPacketWrapper(object):
                  only_schemas,
                  ignored_schemas,
                  freeze_schema,
-                 fail_on_table_metadata_unavailable):
+                 fail_on_table_metadata_unavailable,
+                 ignore_decode_errors):
         # -1 because we ignore the ok byte
         self.read_bytes = 0
         # Used when we want to override a value in the data buffer
@@ -140,7 +141,8 @@ class BinLogPacketWrapper(object):
                                  only_schemas=only_schemas,
                                  ignored_schemas=ignored_schemas,
                                  freeze_schema=freeze_schema,
-                                 fail_on_table_metadata_unavailable=fail_on_table_metadata_unavailable)
+                                 fail_on_table_metadata_unavailable=fail_on_table_metadata_unavailable,
+                                 ignore_decode_errors=ignore_decode_errors)
         if self.event._processed == False:
             self.event = None
 

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -247,7 +247,8 @@ class RowsEvent(BinLogEvent):
         string = self.packet.read_length_coded_pascal_string(size)
         if column.character_set_name is not None:
             encoding = self.charset_to_encoding(column.character_set_name)
-            string = string.decode(encoding)
+            decode_errors = "ignore" if self._ignore_decode_errors else "strict"
+            string = string.decode(encoding, decode_errors)
         return string
 
     def __read_bit(self, column):

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -85,6 +85,11 @@ class PyMySQLReplicationTestCase(base):
         c = self.conn_control.cursor()
         c.execute(query)
         return c
+    
+    def execute_with_args(self, query, args):
+        c = self.conn_control.cursor()
+        c.execute(query, args)
+        return c
 
     def resetBinLog(self):
         self.execute("RESET MASTER")

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -679,13 +679,13 @@ class TestMultipleRowBinLogStreamReader(base.PyMySQLReplicationTestCase):
             assert had_error
 
     def test_ignore_decode_errors(self):
-        problematic_unicode_string = b'[{"type":"paragraph","text":"\xed\xa0\xbd \xed\xb1\x8d Some string"}]'
+        problematic_unicode_string = b'[{"text":"\xed\xa0\xbd \xed\xb1\x8d Some string"}]'
         self.stream.close()
         self.execute("CREATE TABLE test (id INTEGER(11), data VARCHAR(50))")
         self.execute("INSERT INTO test VALUES (1, 'A value')")
         self.execute("COMMIT")
         self.execute("ALTER TABLE test MODIFY COLUMN data VARCHAR(50) CHARACTER SET utf8mb4")
-        self.execute(f"INSERT INTO test VALUES (2, {problematic_unicode_string})")
+        self.execute(f"INSERT INTO test VALUES (2, '{problematic_unicode_string}')")
         self.execute("COMMIT")
 
         self.stream = BinLogStreamReader(

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -685,7 +685,7 @@ class TestMultipleRowBinLogStreamReader(base.PyMySQLReplicationTestCase):
         self.execute("INSERT INTO test VALUES (1, 'A value')")
         self.execute("COMMIT")
         self.execute("ALTER TABLE test MODIFY COLUMN data VARCHAR(50) CHARACTER SET utf8mb4")
-        self.execute(f"INSERT INTO test VALUES (2, '{problematic_unicode_string}')")
+        self.execute_with_args("INSERT INTO test (id, data) VALUES (%s, %s)", (2, problematic_unicode_string))
         self.execute("COMMIT")
 
         self.stream = BinLogStreamReader(


### PR DESCRIPTION
We discovered that some rows in our mysql db contain incorrectly encoded utf8 strings and when iterating through the binary logs, we see the following error when decoding these values:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xed in position 29: invalid continuation byte
```

We'd like to be able to ignore such errors when decoding.

This change introduces a new optional parameter for the `BinLogStreamReader` called `ignore_decode_errors`. When set to True, the malformed data will be ignored.
