### PR TITLE
Fix test code - 'isMariaDB'

### DIFF
--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -67,7 +67,7 @@ class PyMySQLReplicationTestCase(base):
 
     def isMariaDB(self):
         if self.__is_mariaDB is None:
-            self.__is_mariaDB = "MariaDB" in self.execute("SELECT VERSION()").fetchone()
+            self.__is_mariaDB = "MariaDB" in self.execute("SELECT VERSION()").fetchone()[0]
         return self.__is_mariaDB
 
     @property


### PR DESCRIPTION
The result value executed through the fechone() function is passed in the form of a tuple, but the syntax to compare isMariaDB function always has an error that returns False because it checks for string type data
* before code block (pymysqlreplication/tests/base.py)
``` 
    def isMariaDB(self):
        if self.__is_mariaDB is None:
            self.__is_mariaDB = "MariaDB" in self.execute("SELECT VERSION()").fetchone()
        return self.__is_mariaDB
```
* image
![image](https://github.com/julien-duponchelle/python-mysql-replication/assets/65060314/89adc1f3-1ea0-4631-94de-5ebd71d77147)

* fixed
Change to see the first element in the tuple lookup list