### PR TITLE
Developed the Mariadbannotate ros event

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,4 @@ services:
       --log-bin=master-bin
       --binlog-format=row
       --log-slave-updates=on
+      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,16 @@ services:
     ports:
       - 3307:3307
     command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on --log_slave_updates -P 3307
+
+  mariadb-10.6:
+    image: mariadb:10.6
+    environment:
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
+    ports:
+      - "3308:3306"
+    command: |
+      --server-id=1
+      --default-authentication-plugin=mysql_native_password
+      --log-bin=master-bin
+      --binlog-format=row
+      --log-slave-updates=on

--- a/examples/mariadb_gtid/read_event.py
+++ b/examples/mariadb_gtid/read_event.py
@@ -1,12 +1,12 @@
 import pymysql
 
 from pymysqlreplication import BinLogStreamReader, gtid
-from pymysqlreplication.event import GtidEvent, RotateEvent, MariadbGtidEvent, QueryEvent
+from pymysqlreplication.event import GtidEvent, RotateEvent, MariadbGtidEvent, QueryEvent,MariadbAnnotateRowsEvent
 from pymysqlreplication.row_event import WriteRowsEvent, UpdateRowsEvent, DeleteRowsEvent
 
 MARIADB_SETTINGS = {
     "host": "127.0.0.1",
-    "port": 3306,
+    "port": 4306,
     "user": "replication_user",
     "passwd": "secret123passwd",
 }
@@ -65,10 +65,12 @@ if __name__ == "__main__":
             RotateEvent,
             WriteRowsEvent,
             UpdateRowsEvent,
-            DeleteRowsEvent
+            DeleteRowsEvent,
+            MariadbAnnotateRowsEvent
         ],
         auto_position=gtid,
-        is_mariadb=True
+        is_mariadb=True,
+        annotate_rows_event=True
     )
 
     print('Starting reading events from GTID ', gtid)

--- a/examples/mariadb_gtid/read_event.py
+++ b/examples/mariadb_gtid/read_event.py
@@ -6,7 +6,7 @@ from pymysqlreplication.row_event import WriteRowsEvent, UpdateRowsEvent, Delete
 
 MARIADB_SETTINGS = {
     "host": "127.0.0.1",
-    "port": 4306,
+    "port": 3306,
     "user": "replication_user",
     "passwd": "secret123passwd",
 }

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -389,7 +389,7 @@ class BinLogStreamReader(object):
 
                 # Enable annotate rows event 
                 if self.__annotate_rows_event:
-                    flags = 2
+                    flags |= 0x02
 
                 if not self.__blocking:
                     flags |= 0x01  # BINLOG_DUMP_NON_BLOCK

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -181,7 +181,7 @@ class BinLogStreamReader(object):
             is_mariadb: Flag to indicate it's a MariaDB server, used with auto_position
                     to point to Mariadb specific GTID.
             annotate_rows_event: Parameter value to enable annotate rows event in mariadb,
-                    used with auto_position,is_mariadb
+                    used with 'is_mariadb'
             ignore_decode_errors: If true, any decode errors encountered 
                                   when reading column data will be ignored.
         """
@@ -336,73 +336,39 @@ class BinLogStreamReader(object):
         self._register_slave()
 
         if not self.auto_position:
-            # only when log_file and log_pos both provided, the position info is
-            # valid, if not, get the current position from master
-            if self.log_file is None or self.log_pos is None:
-                cur = self._stream_connection.cursor()
-                cur.execute("SHOW MASTER STATUS")
-                master_status = cur.fetchone()
-                if master_status is None:
-                    raise BinLogNotEnabled()
-                self.log_file, self.log_pos = master_status[:2]
-                cur.close()
-
-            prelude = struct.pack('<i', len(self.log_file) + 11) \
-                + bytes(bytearray([COM_BINLOG_DUMP]))
-
-            if self.__resume_stream:
-                prelude += struct.pack('<I', self.log_pos)
-            else:
-                prelude += struct.pack('<I', 4)
-
-            flags = 0
-
-            if not self.__blocking:
-                flags |= 0x01  # BINLOG_DUMP_NON_BLOCK
-            prelude += struct.pack('<H', flags)
-
-            prelude += struct.pack('<I', self.__server_id)
-            prelude += self.log_file.encode()
-        else:
             if self.is_mariadb:
-                # https://mariadb.com/kb/en/5-slave-registration/
-                cur = self._stream_connection.cursor()
-                cur.execute("SET @slave_connect_state='%s'" % self.auto_position)
-                cur.execute("SET @slave_gtid_strict_mode=1")
-                cur.execute("SET @slave_gtid_ignore_duplicates=0")
-                cur.close()
+                prelude = self.__set_mariadb_settings()
+            else:
+                # only when log_file and log_pos both provided, the position info is
+                # valid, if not, get the current position from master
+                if self.log_file is None or self.log_pos is None:
+                    cur = self._stream_connection.cursor()
+                    cur.execute("SHOW MASTER STATUS")
+                    master_status = cur.fetchone()
+                    if master_status is None:
+                        raise BinLogNotEnabled()
+                    self.log_file, self.log_pos = master_status[:2]
+                    cur.close()
 
-                # https://mariadb.com/kb/en/com_binlog_dump/
-                header_size = (
-                        4 +  # binlog pos
-                        2 +  # binlog flags
-                        4 +  # slave server_id,
-                        4    # requested binlog file name , set it to empty
-                )
+                prelude = struct.pack('<i', len(self.log_file) + 11) \
+                    + bytes(bytearray([COM_BINLOG_DUMP]))
 
-                prelude = struct.pack('<i', header_size) + bytes(bytearray([COM_BINLOG_DUMP]))
-
-                # binlog pos
-                prelude += struct.pack('<i', 4)
+                if self.__resume_stream:
+                    prelude += struct.pack('<I', self.log_pos)
+                else:
+                    prelude += struct.pack('<I', 4)
 
                 flags = 0
 
-                # Enable annotate rows event 
-                if self.__annotate_rows_event:
-                    flags |= 0x02 # BINLOG_SEND_ANNOTATE_ROWS_EVENT
-
                 if not self.__blocking:
                     flags |= 0x01  # BINLOG_DUMP_NON_BLOCK
-                
-                # binlog flags
                 prelude += struct.pack('<H', flags)
 
-                # server id (4 bytes)
                 prelude += struct.pack('<I', self.__server_id)
-
-                # empty_binlog_name (4 bytes)
-                prelude += b'\0\0\0\0'
-                
+                prelude += self.log_file.encode()
+        else:
+            if self.is_mariadb:
+                prelude = self.__set_mariadb_settings()        
             else:
                 # Format for mysql packet master_auto_position
                 #
@@ -483,6 +449,48 @@ class BinLogStreamReader(object):
             self._stream_connection._write_bytes(prelude)
             self._stream_connection._next_seq_id = 1
         self.__connected_stream = True
+
+    def __set_mariadb_settings(self):
+        # https://mariadb.com/kb/en/5-slave-registration/
+        cur = self._stream_connection.cursor()
+        if self.auto_position != None : 
+            cur.execute("SET @slave_connect_state='%s'" % self.auto_position)
+        cur.execute("SET @slave_gtid_strict_mode=1")
+        cur.execute("SET @slave_gtid_ignore_duplicates=0")
+        cur.close()
+
+        # https://mariadb.com/kb/en/com_binlog_dump/
+        header_size = (
+                4 +  # binlog pos
+                2 +  # binlog flags
+                4 +  # slave server_id,
+                4    # requested binlog file name , set it to empty
+        )
+
+        prelude = struct.pack('<i', header_size) + bytes(bytearray([COM_BINLOG_DUMP]))
+
+        # binlog pos
+        prelude += struct.pack('<i', 4)
+
+        flags = 0
+
+        # Enable annotate rows event 
+        if self.__annotate_rows_event:
+            flags |= 0x02 # BINLOG_SEND_ANNOTATE_ROWS_EVENT
+
+        if not self.__blocking:
+            flags |= 0x01  # BINLOG_DUMP_NON_BLOCK
+        
+        # binlog flags
+        prelude += struct.pack('<H', flags)
+
+        # server id (4 bytes)
+        prelude += struct.pack('<I', self.__server_id)
+
+        # empty_binlog_name (4 bytes)
+        prelude += b'\0\0\0\0'
+
+        return prelude
 
     def fetchone(self):
         while True:

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -389,7 +389,7 @@ class BinLogStreamReader(object):
 
                 # Enable annotate rows event 
                 if self.__annotate_rows_event:
-                    flags |= 0x02
+                    flags |= 0x02 # BINLOG_SEND_ANNOTATE_ROWS_EVENT
 
                 if not self.__blocking:
                     flags |= 0x01  # BINLOG_DUMP_NON_BLOCK

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -110,6 +110,7 @@ class MariadbGtidEvent(BinLogEvent):
         print("Flags:", self.flags)
         print('GTID:', self.gtid)
 
+
 class MariadbAnnotateRowsEvent(BinLogEvent):
     """
     Annotate rows event 

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -110,6 +110,23 @@ class MariadbGtidEvent(BinLogEvent):
         print("Flags:", self.flags)
         print('GTID:', self.gtid)
 
+class MariadbAnnotateRowsEvent(BinLogEvent):
+    """
+    Annotate rows event 
+    If you want to check this binlog, change the value of the flag(line 382 of the 'binlogstream.py') option to 2 
+    https://mariadb.com/kb/en/annotate_rows_event/
+
+    Attributes:
+        sql_statement: The SQL statement
+    """
+    def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
+        super(MariadbAnnotateRowsEvent, self).__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
+        self.sql_statement = self.packet.read(event_size)
+
+    def _dump(self):
+        super(MariadbAnnotateRowsEvent, self)._dump()
+        print("SQL statement :", self.sql_statement)   
+
 
 class RotateEvent(BinLogEvent):
     """Change MySQL bin log file

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -83,7 +83,7 @@ class BinLogPacketWrapper(object):
         constants.ANONYMOUS_GTID_LOG_EVENT: event.NotImplementedEvent,
         constants.PREVIOUS_GTIDS_LOG_EVENT: event.NotImplementedEvent,
         # MariaDB GTID
-        constants.MARIADB_ANNOTATE_ROWS_EVENT: event.NotImplementedEvent,
+        constants.MARIADB_ANNOTATE_ROWS_EVENT: event.MariadbAnnotateRowsEvent,
         constants.MARIADB_BINLOG_CHECKPOINT_EVENT: event.NotImplementedEvent,
         constants.MARIADB_GTID_EVENT: event.MariadbGtidEvent,
         constants.MARIADB_GTID_GTID_LIST_EVENT: event.NotImplementedEvent,

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -121,3 +121,27 @@ class PyMySQLReplicationTestCase(base):
         bin_log_basename = cursor.fetchone()[0]
         bin_log_basename = bin_log_basename.split("/")[-1]
         return bin_log_basename
+
+class PyMySQLReplicationMariaDbTestCase(PyMySQLReplicationTestCase):
+    def setUp(self):
+        # default
+        self.database = {
+            "host": "localhost",
+            "user": "root",
+            "passwd": "",
+            "port": 3308,
+            "use_unicode": True,
+            "charset": "utf8",
+            "db": "pymysqlreplication_test"
+        }
+
+        self.conn_control = None
+        db = copy.copy(self.database)
+        db["db"] = None
+        self.connect_conn_control(db)
+        self.execute("DROP DATABASE IF EXISTS pymysqlreplication_test")
+        self.execute("CREATE DATABASE pymysqlreplication_test")
+        db = copy.copy(self.database)
+        self.connect_conn_control(db)
+        self.stream = None
+        self.resetBinLog()

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -122,6 +122,7 @@ class PyMySQLReplicationTestCase(base):
         bin_log_basename = bin_log_basename.split("/")[-1]
         return bin_log_basename
 
+
 class PyMySQLReplicationMariaDbTestCase(PyMySQLReplicationTestCase):
     def setUp(self):
         # default
@@ -145,3 +146,4 @@ class PyMySQLReplicationMariaDbTestCase(PyMySQLReplicationTestCase):
         self.connect_conn_control(db)
         self.stream = None
         self.resetBinLog()
+        

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -17,7 +17,7 @@ from pymysqlreplication.exceptions import TableMetadataUnavailableError
 from pymysqlreplication.constants.BINLOG import *
 from pymysqlreplication.row_event import *
 
-__all__ = ["TestBasicBinLogStreamReader", "TestMultipleRowBinLogStreamReader", "TestCTLConnectionSettings", "TestGtidBinLogStreamReader","TestMariadbBinlogStreaReader"]
+__all__ = ["TestBasicBinLogStreamReader", "TestMultipleRowBinLogStreamReader", "TestCTLConnectionSettings", "TestGtidBinLogStreamReader","TestMariadbBinlogStreamReader"]
 
 
 class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1027,7 +1027,10 @@ class TestMariadbBinlogStreaReader(base.PyMySQLReplicationMariaDbTestCase):
             )
         
         event = self.stream.fetchone()
+        #Check event type 160,MariadbAnnotateRowsEvent
         self.assertEqual(event.event_type,160)
+        #Check self.sql_statement
+        self.assertEqual(event.sql_statement,b"INSERT INTO test (id, data) VALUES(1, 'Hello')")
         self.assertIsInstance(event,MariadbAnnotateRowsEvent)
         
 

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1002,20 +1002,30 @@ class GtidTests(unittest.TestCase):
             gtid = Gtid("57b70f4e-20d3-11e5-a393-4a63946f7eac:1-:1")
             gtid = Gtid("57b70f4e-20d3-11e5-a393-4a63946f7eac::1")
 
-class TestMariadbBinlogStreaReader(base.PyMySQLReplicationTestCase):
-    def setUp(self):
-        super(TestMariadbBinlogStreaReader,self).setUp()
-        if not self.isMariaDB():
-            raise unittest.SkipTest("Skipping test: Not a MariaDB instance")
+class TestMariadbBinlogStreaReader(base.PyMySQLReplicationMariaDbTestCase):
     
     def test_annotate_rows_evet(self):
         query = "CREATE TABLE test (id INT NOT NULL AUTO_INCREMENT, data VARCHAR (50) NOT NULL, PRIMARY KEY (id))"
         self.execute(query)
-        
+        # Insert first event
+        query = "BEGIN;"
+        self.execute(query)
+        query = "INSERT INTO test (id, data) VALUES(1, 'Hello');"
+        self.execute(query)
+        query = "COMMIT;"
+        self.execute(query)
+
         self.stream.close()
         self.stream = BinLogStreamReader(
-            self.database, server_id=1024, blocking=False,is_mariadb=True,only_events=[MariadbAnnotateRowsEvent],auto_position="0-1-1",is_mariadb=True,annotate_rows_event=True,
+            self.database, 
+            server_id=1024, 
+            blocking=False,
+            only_events=[MariadbAnnotateRowsEvent],
+            auto_position="0-1-1",
+            is_mariadb=True,
+            annotate_rows_event=True,
             )
+        
         event = self.stream.fetchone()
         self.assertEqual(event.event_type,160)
         self.assertIsInstance(event,MariadbAnnotateRowsEvent)

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1010,8 +1010,8 @@ class TestMariadbBinlogStreaReader(base.PyMySQLReplicationMariaDbTestCase):
         # Insert first event
         query = "BEGIN;"
         self.execute(query)
-        query = "INSERT INTO test (id, data) VALUES(1, 'Hello');"
-        self.execute(query)
+        insert_query = b"INSERT INTO test (id, data) VALUES(1, 'Hello')"
+        self.execute(insert_query)
         query = "COMMIT;"
         self.execute(query)
 
@@ -1021,7 +1021,6 @@ class TestMariadbBinlogStreaReader(base.PyMySQLReplicationMariaDbTestCase):
             server_id=1024, 
             blocking=False,
             only_events=[MariadbAnnotateRowsEvent],
-            auto_position="0-1-1",
             is_mariadb=True,
             annotate_rows_event=True,
             )
@@ -1030,7 +1029,7 @@ class TestMariadbBinlogStreaReader(base.PyMySQLReplicationMariaDbTestCase):
         #Check event type 160,MariadbAnnotateRowsEvent
         self.assertEqual(event.event_type,160)
         #Check self.sql_statement
-        self.assertEqual(event.sql_statement,b"INSERT INTO test (id, data) VALUES(1, 'Hello')")
+        self.assertEqual(event.sql_statement,insert_query)
         self.assertIsInstance(event,MariadbAnnotateRowsEvent)
         
 

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1002,9 +1002,9 @@ class GtidTests(unittest.TestCase):
             gtid = Gtid("57b70f4e-20d3-11e5-a393-4a63946f7eac:1-:1")
             gtid = Gtid("57b70f4e-20d3-11e5-a393-4a63946f7eac::1")
 
-class TestMariadbBinlogStreaReader(base.PyMySQLReplicationMariaDbTestCase):
+class TestMariadbBinlogStreamReader(base.PyMySQLReplicationMariaDbTestCase):
     
-    def test_annotate_rows_evet(self):
+    def test_annotate_rows_event(self):
         query = "CREATE TABLE test (id INT NOT NULL AUTO_INCREMENT, data VARCHAR (50) NOT NULL, PRIMARY KEY (id))"
         self.execute(query)
         # Insert first event

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -25,9 +25,9 @@ class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
         return [GtidEvent]
 
     def test_allowed_event_list(self):
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 16)
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 15)
-        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 15)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 17)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 16)
+        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 16)
         self.assertEqual(len(self.stream._allowed_event_list([RotateEvent], None, False)), 1)
 
     def test_read_query_event(self):


### PR DESCRIPTION
# mariadb-annotate-rows-event

## 1. Development of 'MariadbAnnotateRowsEvent' 

- Developed the `MariadbAnnotateRowsEvent` class based on the following document
  - Documentation link: [https://mariadb.com/kb/en/annotate_rows_event/](https://mariadb.com/kb/en/annotate_rows_event/)
  - [link to the source code](https://github.com/cucuridas/python-mysql-replication/blob/d698c1125cbeda6f461fa113320f2144f3531f1a/pymysqlreplication/event.py#L114-L129)

## 2. Changes to the Binlogstream Object for MariaDB Replication

- Updated the **isMariadb field to check for MariaDB and set the 'mariadb settings'** (`__set_mariadb_settings`) accordingly.
  - Previous behavior: Only checked if the `auto_position` field existed for MariaDB detection.
  - Updated behavior: Now detects MariaDB even if the `auto_position` field is not specified.
  - [[link to the source code]](https://github.com/cucuridas/python-mysql-replication/blob/d698c1125cbeda6f461fa113320f2144f3531f1a/pymysqlreplication/binlogstream.py#L338-L443)

- Added the **annotate_rows_event field to enable the specific feature**.
  - Additional binlog events are triggered when rows event occurs, so the binlogstream object now accepts the `annotate_rows_event` parameter to activate this feature.
  - Source code:[[Source code with parameter defined]](https://github.com/cucuridas/python-mysql-replication/blob/d698c1125cbeda6f461fa113320f2144f3531f1a/pymysqlreplication/binlogstream.py#L145),  [[Conditional expression to check '__annotate_rows_event']](https://github.com/cucuridas/python-mysql-replication/blob/d698c1125cbeda6f461fa113320f2144f3531f1a/pymysqlreplication/binlogstream.py#L478-L479)
  
## 3. Test code
- Adding Mariadb Test Service to docker-compose.yml
  - [[link yml file]](https://github.com/cucuridas/python-mysql-replication/blob/d698c1125cbeda6f461fa113320f2144f3531f1a/docker-compose.yml#L19-L30)
- Adding TestMariadbBinlogStreamReader Object to base.py
  - [[link to  the source code]](https://github.com/cucuridas/python-mysql-replication/blob/d698c1125cbeda6f461fa113320f2144f3531f1a/pymysqlreplication/tests/base.py#L126-L148)
- Writing Test Code for `annotate_rows_event`
  - [[link to the source code]](https://github.com/cucuridas/python-mysql-replication/blob/d698c1125cbeda6f461fa113320f2144f3531f1a/pymysqlreplication/tests/test_basic.py#L1005-L1033)