### PR TITLE
Fix typo in development.rst

### DIFF
--- a/docs/developement.rst
+++ b/docs/developement.rst
@@ -23,7 +23,7 @@ When it's possible we have an unit test.
 *pymysqlreplication/tests/* contains the test suite. The test suite
 use the standard *unittest* Python module.
 
-**Be carefull** tests will reset the binary log of your MySQL server.
+**Be careful** tests will reset the binary log of your MySQL server.
 
 Make sure you have the following configuration set in your mysql config file (usually my.cnf on development env):
 


### PR DESCRIPTION
### Fix Typo

I noticed a small typo in the "Tests" section of the Development page. The word "carefull" should be corrected to "careful."

Thank you for considering this fix!