### PR TITLE
Fix typo in row_event.py

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -642,7 +642,7 @@ class TableMapEvent(BinLogEvent):
 
                     ordinal_pos_loc += 1
                 except IndexError:
-                    # this a dirty hack to prevent row events containing columns which have been dropped prior
+                    # this is a dirty hack to prevent row events containing columns which have been dropped prior
                     # to pymysqlreplication start, but replayed from binlog from blowing up the service.
                     # TODO: this does not address the issue if the column other than the last one is dropped
                     column_schema = {


### PR DESCRIPTION
This PR addresses a typo found in the row_event.py.

this a dirty hack -> this `is` a dirty hack