### PR TITLE
fix - Bug/increase history list length

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -256,6 +256,7 @@ class BinLogStreamReader(object):
             self._ctl_connection_settings = dict(self.__connection_settings)
         self._ctl_connection_settings["db"] = "information_schema"
         self._ctl_connection_settings["cursorclass"] = DictCursor
+        self._ctl_connection_settings["autocommit"] = True
         self._ctl_connection = self.pymysql_wrapper(**self._ctl_connection_settings)
         self._ctl_connection._get_table_information = self.__get_table_information
         self.__connected_ctl = True

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -653,6 +653,7 @@ class BinLogStreamReader(object):
                         table_schema = %s AND table_name = %s
                     ORDER BY ORDINAL_POSITION
                     """, (schema, table))
+                cur.execute("COMMIT")
 
                 return cur.fetchall()
             except pymysql.OperationalError as error:

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -655,6 +655,7 @@ class BinLogStreamReader(object):
                     """, (schema, table))
                 result = cur.fetchall()
                 cur.execute("COMMIT")
+                cur.close()
 
                 return result
             except pymysql.OperationalError as error:

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -653,9 +653,10 @@ class BinLogStreamReader(object):
                         table_schema = %s AND table_name = %s
                     ORDER BY ORDINAL_POSITION
                     """, (schema, table))
+                result = cur.fetchall()
                 cur.execute("COMMIT")
 
-                return cur.fetchall()
+                return result
             except pymysql.OperationalError as error:
                 code, message = error.args
                 if code in MYSQL_EXPECTED_ERROR_CODES:

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -655,7 +655,6 @@ class BinLogStreamReader(object):
                     ORDER BY ORDINAL_POSITION
                     """, (schema, table))
                 result = cur.fetchall()
-                cur.execute("COMMIT")
                 cur.close()
 
                 return result


### PR DESCRIPTION
### Overview
issue number #430

When using the `pymysqlreplication` package, there was a recurring issue with the `history list length` value under the following circumstances:

- MySQL version 8.x or higher.
- Continuous execution of DML (Data Manipulation Language) statements.

**This problem led to a gradual slowing down of SELECT queries.**

For detailed information, you can refer to the following reference:

https://minervadb.xyz/troubleshooting-innodb-history-length-with-hung-mysql-transaction/

As a result, I investigated the problem area and made necessary modifications. After making the changes, you were able to compare the performance before and after the fix, using monitoring tools such as Prometheus and MySQL Exporter.

### Fixed

    
- **Modified code**
    
    ```python
    def __get_table_information(self, schema, table):
            for i in range(1, 3):
                try:
                    if not self.__connected_ctl:
                        self.__connect_to_ctl()
    
                    cur = self._ctl_connection.cursor()
                    cur.execute("""
                        SELECT
                            COLUMN_NAME, COLLATION_NAME, CHARACTER_SET_NAME,
                            COLUMN_COMMENT, COLUMN_TYPE, COLUMN_KEY, ORDINAL_POSITION,
                            DATA_TYPE, CHARACTER_OCTET_LENGTH
                        FROM
                            information_schema.columns
                        WHERE
    			  table_schema = %s AND table_name = %s
                        ORDER BY ORDINAL_POSITION
                        """, (schema, table))
                    result = cur.fetchall()
                    cur.close()
    
                    return result
    								...
    								...
    ```
    

### Performance Comparison After the Code Modifications

- Before modification </br>
 ![image](https://github.com/julien-duponchelle/python-mysql-replication/assets/65060314/7a1047c3-446d-469d-9092-a5452e36083b)   
 
- After modification </br>    
 ![image](https://github.com/julien-duponchelle/python-mysql-replication/assets/65060314/63310638-e4ad-4b8a-bf0c-14ea73ddf1d1)
