### PR TITLE
Refactor super() usage in classes

### DIFF
--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -56,7 +56,7 @@ class GtidEvent(BinLogEvent):
     """GTID change in binlog event
     """
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(GtidEvent, self).__init__(from_packet, event_size, table_map,
+        super().__init__(from_packet, event_size, table_map,
                                           ctl_connection, **kwargs)
 
         self.commit_flag = struct.unpack("!B", self.packet.read(1))[0] == 1
@@ -97,7 +97,7 @@ class MariadbGtidEvent(BinLogEvent):
     """
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
 
-        super(MariadbGtidEvent, self).__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
+        super().__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
 
         self.server_id = self.packet.server_id
         self.gtid_seq_no = self.packet.read_uint64()
@@ -106,7 +106,7 @@ class MariadbGtidEvent(BinLogEvent):
         self.gtid = "%d-%d-%d" % (self.domain_id, self.server_id, self.gtid_seq_no)
 
     def _dump(self):
-        super(MariadbGtidEvent, self)._dump()
+        super()._dump()
         print("Flags:", self.flags)
         print('GTID:', self.gtid)
 
@@ -121,11 +121,11 @@ class MariadbAnnotateRowsEvent(BinLogEvent):
         sql_statement: The SQL statement
     """
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(MariadbAnnotateRowsEvent, self).__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
+        super().__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
         self.sql_statement = self.packet.read(event_size)
 
     def _dump(self):
-        super(MariadbAnnotateRowsEvent, self)._dump()
+        super()._dump()
         print("SQL statement :", self.sql_statement)   
 
 
@@ -137,7 +137,7 @@ class RotateEvent(BinLogEvent):
         next_binlog: Name of next binlog file
     """
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(RotateEvent, self).__init__(from_packet, event_size, table_map,
+        super().__init__(from_packet, event_size, table_map,
                                           ctl_connection, **kwargs)
         self.position = struct.unpack('<Q', self.packet.read(8))[0]
         self.next_binlog = self.packet.read(event_size - 8).decode()
@@ -158,7 +158,7 @@ class XAPrepareEvent(BinLogEvent):
         xid: serialized XID representation of XA transaction
     """
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(XAPrepareEvent, self).__init__(from_packet, event_size, table_map,
+        super().__init__(from_packet, event_size, table_map,
                                           ctl_connection, **kwargs)
 
         # one_phase is True: XA COMMIT ... ONE PHASE
@@ -182,7 +182,7 @@ class XAPrepareEvent(BinLogEvent):
 
 class FormatDescriptionEvent(BinLogEvent):
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(FormatDescriptionEvent, self).__init__(from_packet, event_size, table_map,
+        super().__init__(from_packet, event_size, table_map,
                                           ctl_connection, **kwargs)
         self.binlog_version = struct.unpack('<H', self.packet.read(2))
         self.mysql_version_str = self.packet.read(50).rstrip(b'\0').decode()
@@ -206,12 +206,12 @@ class XidEvent(BinLogEvent):
     """
 
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(XidEvent, self).__init__(from_packet, event_size, table_map,
+        super().__init__(from_packet, event_size, table_map,
                                        ctl_connection, **kwargs)
         self.xid = struct.unpack('<Q', self.packet.read(8))[0]
 
     def _dump(self):
-        super(XidEvent, self)._dump()
+        super()._dump()
         print("Transaction ID: %d" % (self.xid))
 
 
@@ -236,13 +236,13 @@ class HeartbeatLogEvent(BinLogEvent):
     """
 
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(HeartbeatLogEvent, self).__init__(from_packet, event_size,
+        super().__init__(from_packet, event_size,
                                                 table_map, ctl_connection,
                                                 **kwargs)
         self.ident = self.packet.read(event_size).decode()
 
     def _dump(self):
-        super(HeartbeatLogEvent, self)._dump()
+        super()._dump()
         print("Current binlog: %s" % (self.ident))
 
 
@@ -250,7 +250,7 @@ class QueryEvent(BinLogEvent):
     '''This event is trigger when a query is run of the database.
     Only replicated queries are logged.'''
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(QueryEvent, self).__init__(from_packet, event_size, table_map,
+        super().__init__(from_packet, event_size, table_map,
                                          ctl_connection, **kwargs)
 
         # Post-header
@@ -276,7 +276,7 @@ class QueryEvent(BinLogEvent):
         #string[EOF]    query
 
     def _dump(self):
-        super(QueryEvent, self)._dump()
+        super()._dump()
         print("Schema: %s" % (self.schema))
         print("Execution time: %d" % (self.execution_time))
         print("Query: %s" % (self.query))
@@ -376,7 +376,7 @@ class BeginLoadQueryEvent(BinLogEvent):
         block-data
     """
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(BeginLoadQueryEvent, self).__init__(from_packet, event_size, table_map,
+        super().__init__(from_packet, event_size, table_map,
                                                      ctl_connection, **kwargs)
 
         # Payload
@@ -384,7 +384,7 @@ class BeginLoadQueryEvent(BinLogEvent):
         self.block_data = self.packet.read(event_size - 4)
 
     def _dump(self):
-        super(BeginLoadQueryEvent, self)._dump()
+        super()._dump()
         print("File id: %d" % (self.file_id))
         print("Block data: %s" % (self.block_data))
 
@@ -405,7 +405,7 @@ class ExecuteLoadQueryEvent(BinLogEvent):
         dup_handling_flags
     """
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(ExecuteLoadQueryEvent, self).__init__(from_packet, event_size, table_map,
+        super().__init__(from_packet, event_size, table_map,
                                                         ctl_connection, **kwargs)
 
         # Post-header
@@ -442,7 +442,7 @@ class IntvarEvent(BinLogEvent):
         value
     """
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(IntvarEvent, self).__init__(from_packet, event_size, table_map,
+        super().__init__(from_packet, event_size, table_map,
                                           ctl_connection, **kwargs)
 
         # Payload
@@ -450,7 +450,7 @@ class IntvarEvent(BinLogEvent):
         self.value = self.packet.read_uint32()
 
     def _dump(self):
-        super(IntvarEvent, self)._dump()
+        super()._dump()
         print("type: %d" % (self.type))
         print("Value: %d" % (self.value))
 
@@ -467,7 +467,7 @@ class RandEvent(BinLogEvent):
     """
     
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(RandEvent, self).__init__(from_packet, event_size, table_map,
+        super().__init__(from_packet, event_size, table_map,
                                         ctl_connection, **kwargs)
         # Payload
         self._seed1 = self.packet.read_uint64()
@@ -484,7 +484,7 @@ class RandEvent(BinLogEvent):
         return self._seed2
 
     def _dump(self):
-        super(RandEvent, self)._dump()
+        super()._dump()
         print("seed1: %d" % (self.seed1))
         print("seed2: %d" % (self.seed2))
 
@@ -505,7 +505,7 @@ class MariadbStartEncryptionEvent(BinLogEvent):
     """
 
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(MariadbStartEncryptionEvent, self).__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
+        super().__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
 
         self.schema = self.packet.read_uint8()
         self.key_version = self.packet.read_uint32()
@@ -519,6 +519,6 @@ class MariadbStartEncryptionEvent(BinLogEvent):
 
 class NotImplementedEvent(BinLogEvent):
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(NotImplementedEvent, self).__init__(
+        super().__init__(
             from_packet, event_size, table_map, ctl_connection, **kwargs)
         self.packet.advance(event_size)

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -17,7 +17,7 @@ from .bitmap import BitCount, BitGet
 
 class RowsEvent(BinLogEvent):
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(RowsEvent, self).__init__(from_packet, event_size, table_map,
+        super().__init__(from_packet, event_size, table_map,
                                         ctl_connection, **kwargs)
         self.__rows = None
         self.__only_tables = kwargs["only_tables"]
@@ -449,7 +449,7 @@ class RowsEvent(BinLogEvent):
         return binary & mask
 
     def _dump(self):
-        super(RowsEvent, self)._dump()
+        super()._dump()
         print("Table: %s.%s" % (self.schema, self.table))
         print("Affected columns: %d" % self.number_of_columns)
         print("Changed rows: %d" % (len(self.rows)))
@@ -477,7 +477,7 @@ class DeleteRowsEvent(RowsEvent):
     """
 
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(DeleteRowsEvent, self).__init__(from_packet, event_size,
+        super().__init__(from_packet, event_size,
                                               table_map, ctl_connection, **kwargs)
         if self._processed:
             self.columns_present_bitmap = self.packet.read(
@@ -490,7 +490,7 @@ class DeleteRowsEvent(RowsEvent):
         return row
 
     def _dump(self):
-        super(DeleteRowsEvent, self)._dump()
+        super()._dump()
         print("Values:")
         for row in self.rows:
             print("--")
@@ -505,7 +505,7 @@ class WriteRowsEvent(RowsEvent):
     """
 
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(WriteRowsEvent, self).__init__(from_packet, event_size,
+        super().__init__(from_packet, event_size,
                                              table_map, ctl_connection, **kwargs)
         if self._processed:
             self.columns_present_bitmap = self.packet.read(
@@ -518,7 +518,7 @@ class WriteRowsEvent(RowsEvent):
         return row
 
     def _dump(self):
-        super(WriteRowsEvent, self)._dump()
+        super()._dump()
         print("Values:")
         for row in self.rows:
             print("--")
@@ -538,7 +538,7 @@ class UpdateRowsEvent(RowsEvent):
     """
 
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(UpdateRowsEvent, self).__init__(from_packet, event_size,
+        super().__init__(from_packet, event_size,
                                               table_map, ctl_connection, **kwargs)
         if self._processed:
             #Body
@@ -556,7 +556,7 @@ class UpdateRowsEvent(RowsEvent):
         return row
 
     def _dump(self):
-        super(UpdateRowsEvent, self)._dump()
+        super()._dump()
         print("Affected columns: %d" % self.number_of_columns)
         print("Values:")
         for row in self.rows:
@@ -574,7 +574,7 @@ class TableMapEvent(BinLogEvent):
     """
 
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(TableMapEvent, self).__init__(from_packet, event_size,
+        super().__init__(from_packet, event_size,
                                             table_map, ctl_connection, **kwargs)
         self.__only_tables = kwargs["only_tables"]
         self.__ignored_tables = kwargs["ignored_tables"]
@@ -669,7 +669,7 @@ class TableMapEvent(BinLogEvent):
         return self.table_obj
 
     def _dump(self):
-        super(TableMapEvent, self)._dump()
+        super()._dump()
         print("Table id: %d" % (self.table_id))
         print("Schema: %s" % (self.schema))
         print("Table: %s" % (self.table))

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -766,7 +766,7 @@ class TestMultipleRowBinLogStreamReader(base.PyMySQLReplicationTestCase):
 class TestCTLConnectionSettings(base.PyMySQLReplicationTestCase):
 
     def setUp(self):
-        super(TestCTLConnectionSettings, self).setUp()
+        super().setUp()
         self.stream.close()
         ctl_db = copy.copy(self.database)
         ctl_db["db"] = None
@@ -788,7 +788,7 @@ class TestCTLConnectionSettings(base.PyMySQLReplicationTestCase):
         )
 
     def tearDown(self):
-        super(TestCTLConnectionSettings, self).tearDown()
+        super().tearDown()
         self.ctl_conn_control.close()
 
     def test_separate_ctl_settings_table_metadata_unavailable(self):
@@ -823,7 +823,7 @@ class TestCTLConnectionSettings(base.PyMySQLReplicationTestCase):
 
 class TestGtidBinLogStreamReader(base.PyMySQLReplicationTestCase):
     def setUp(self):
-        super(TestGtidBinLogStreamReader, self).setUp()
+        super().setUp()
         if not self.supportsGTID:
             raise unittest.SkipTest("database does not support GTID, skipping GTID tests")
 
@@ -1075,7 +1075,7 @@ class TestMariadbBinlogStreamReader(base.PyMySQLReplicationMariaDbTestCase):
         
 class TestStatementConnectionSetting(base.PyMySQLReplicationTestCase):
     def setUp(self):
-        super(TestStatementConnectionSetting, self).setUp()
+        super().setUp()
         self.stream.close()
         self.stream = BinLogStreamReader(
             self.database,
@@ -1102,7 +1102,7 @@ class TestStatementConnectionSetting(base.PyMySQLReplicationTestCase):
     def tearDown(self):
         self.execute("SET @@binlog_format='ROW'")
         self.assertEqual(self.bin_log_format(), "ROW")
-        super(TestStatementConnectionSetting, self).tearDown()        
+        super().tearDown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This PR addresses the use of the `super()` function in the classes. Starting with Python 3, `super()` can be called without arguments in instance methods, automatically determining the class and self. This PR applies this simplification, enhancing the code's readability and maintainability.

### Changes
- Replaced all occurrences of `super(ClassName, self).__init__` with the simplified `super().__init__` in the classes.

### Before
```python
super(ClassName, self).__init__(from_packet, event_size, table_map) ...
```

### After
```python
super().__init__(from_packet, event_size, table_map) ...
```

### Benefits
- **Readability**: The new syntax is cleaner and more in line with modern Python practices.
- **Maintainability**: If the class name changes in the future, there's no need to update the call to `super()`.


### Related Issue
Fixed: #432 