### PR TITLE
Eliminate `log_slave_updates` system variable, closes #410

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -8,7 +8,7 @@ services:
       MYSQL_DATABASE: pymysqlreplication_test
     ports:
       - 3306:3306
-    command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on --log_slave_updates
+    command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on
     restart: always
     networks:
       - default
@@ -20,7 +20,7 @@ services:
       MYSQL_DATABASE: pymysqlreplication_test
     ports:
       - 3307:3307
-    command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on --log_slave_updates -P 3307
+    command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on -P 3307
 
   pymysqlreplication:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: true
     ports:
       - 3306:3306
-    command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on --log_slave_updates
+    command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on
 
   percona-5.7-ctl:
     image: percona:5.7
@@ -14,7 +14,7 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: true
     ports:
       - 3307:3307
-    command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on --log_slave_updates -P 3307
+    command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on -P 3307
 
   mariadb-10.6:
     image: mariadb:10.6


### PR DESCRIPTION
This PR addresses https://github.com/23-OSSCA-python-mysql-replication/python-mysql-replication/issues/23, https://github.com/julien-duponchelle/python-mysql-replication/issues/410