### PR TITLE
fix read column Info from table map event

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -79,8 +79,9 @@ class RowsEvent(BinLogEvent):
         #Body
         self.number_of_columns = self.packet.read_length_coded_binary()
         self.columns = self.table_map[self.table_id].columns
+        column_schemas = self.table_map[self.table_id].column_schemas
 
-        if len(self.columns) == 0:  # could not read the table metadata, probably already dropped
+        if len(column_schemas) == 0:  # could not read the table metadata, probably already dropped
             self.complete = False
             if self._fail_on_table_metadata_unavailable:
                 raise TableMetadataUnavailableError(self.table)

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -624,7 +624,7 @@ class TableMapEvent(BinLogEvent):
 
         ordinal_pos_loc = 0
 
-        if len(self.column_schemas) != 0:
+        if self.column_count != 0:
             # Read columns meta data
             column_types = bytearray(self.packet.read(self.column_count))
             self.packet.read_length_coded_binary()


### PR DESCRIPTION
fix: #439  

Here is how the scenario Goes:

1. There is a time difference between the event and the actual state of the database.
2. The actual database is dropped.
3. The python-replication-mysql application receives a table map event.
4. Since there is no cached result for the table_id, it tries to retrieve the database's column schema.
5. There are no column schema results from the database.
6. Packets containing information about the table map event's columns are still present.
7. The application exits the if statement, and the packets remain untouched.
8. Incorrect packets are inserted into the null_bitmask.

```
        if self.table_id in table_map:
            self.column_schemas = table_map[self.table_id].column_schemas
        else:
            self.column_schemas = self._ctl_connection._get_table_information(self.schema, self.table)

        ordinal_pos_loc = 0

        if len(self.column_schemas) != 0:
            # Read columns meta data
            column_types = bytearray(self.packet.read(self.column_count))
            
        self.null_bitmask = self.packet.read((self.column_count + 7) / 8) #error packet goes here!
```
