### PR TITLE
Developed ‘MariadbGtidListEvent‘ class

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -13,7 +13,8 @@ from .event import (
     XidEvent, GtidEvent, StopEvent, XAPrepareEvent,
     BeginLoadQueryEvent, ExecuteLoadQueryEvent,
     HeartbeatLogEvent, NotImplementedEvent, MariadbGtidEvent,
-    MariadbAnnotateRowsEvent, RandEvent, MariadbStartEncryptionEvent, RowsQueryLogEvent)
+    MariadbAnnotateRowsEvent, RandEvent, MariadbStartEncryptionEvent, RowsQueryLogEvent,
+    MariadbGtidListEvent)
 from .exceptions import BinLogNotEnabled
 from .gtid import GtidSet
 from .packet import BinLogPacketWrapper
@@ -624,6 +625,7 @@ class BinLogStreamReader(object):
                 MariadbAnnotateRowsEvent,
                 RandEvent,
                 MariadbStartEncryptionEvent,
+                MariadbGtidListEvent
             ))
         if ignored_events is not None:
             for e in ignored_events:

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -126,7 +126,41 @@ class MariadbAnnotateRowsEvent(BinLogEvent):
 
     def _dump(self):
         super()._dump()
-        print("SQL statement :", self.sql_statement)   
+        print("SQL statement :", self.sql_statement)
+
+class MariadbGtidListEvent(BinLogEvent):
+    """
+    GTID List event
+    https://mariadb.com/kb/en/gtid_list_event/
+
+    Attributes:
+        gtid_length: Number of GTIDs
+        gtid_list: list of 'MariadbGtidObejct'
+
+        'MariadbGtidObejct' Attributes:
+            domain_id: Replication Domain ID
+            server_id: Server_ID
+            gtid_seq_no: GTID sequence
+            gtid: 'domain_id'+ 'server_id' + 'gtid_seq_no'
+    """
+    def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
+
+        super(MariadbGtidListEvent, self).__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
+
+        class MariadbGtidObejct(BinLogEvent):
+            """
+            Information class of elements in GTID list
+            """
+            def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
+                super(MariadbGtidObejct, self).__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
+                self.domain_id = self.packet.read_uint32()
+                self.server_id = self.packet.server_id
+                self.gtid_seq_no = self.packet.read_uint64()
+                self.gtid = "%d-%d-%d" % (self.domain_id, self.server_id, self.gtid_seq_no)
+
+
+        self.gtid_length = self.packet.read_uint32()
+        self.gtid_list = [MariadbGtidObejct(from_packet, event_size, table_map, ctl_connection, **kwargs) for i in range(self.gtid_length)]
 
 
 class RotateEvent(BinLogEvent):

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -154,7 +154,7 @@ class MariadbGtidListEvent(BinLogEvent):
             def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
                 super(MariadbGtidObejct, self).__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
                 self.domain_id = self.packet.read_uint32()
-                self.server_id = self.packet.server_id
+                self.server_id = self.packet.read_uint32()
                 self.gtid_seq_no = self.packet.read_uint64()
                 self.gtid = "%d-%d-%d" % (self.domain_id, self.server_id, self.gtid_seq_no)
 

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -89,7 +89,7 @@ class BinLogPacketWrapper(object):
         constants.MARIADB_ANNOTATE_ROWS_EVENT: event.MariadbAnnotateRowsEvent,
         constants.MARIADB_BINLOG_CHECKPOINT_EVENT: event.NotImplementedEvent,
         constants.MARIADB_GTID_EVENT: event.MariadbGtidEvent,
-        constants.MARIADB_GTID_GTID_LIST_EVENT: event.NotImplementedEvent,
+        constants.MARIADB_GTID_GTID_LIST_EVENT: event.MariadbGtidListEvent,
         constants.MARIADB_START_ENCRYPTION_EVENT: event.MariadbStartEncryptionEvent
     }
 


### PR DESCRIPTION
### Overview

The developed class represents an event in MariaDB's binlog files that indicates which GTIDs were written in the previous file when a new binlog file is added.

This event enables users to inspect the last recorded GTID in the previous binlog file, which can be used as an attribute such as 'auto_position'.

**Development Content**

- Created the 'MariadbGtidListEvent' event class (Referenced the link below for development)
    
    https://mariadb.com/kb/en/gtid_list_event/
    
- Added test code for the MariadbGTIDListEventParser class
    
    [[link]- test code](https://github.com/23-OSSCA-python-mysql-replication/python-mysql-replication/blob/a7199da62730f408a1c06ad9a067f6d051f4d94b/pymysqlreplication/tests/test_basic.py#L1080-L1110)