### PR TITLE
Optimize `Handler_read_rnd` by removing ORDER BY clause

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -651,7 +651,6 @@ class BinLogStreamReader(object):
                         information_schema.columns
                     WHERE
                         table_schema = %s AND table_name = %s
-                    ORDER BY ORDINAL_POSITION
                     """, (schema, table))
                 result = cur.fetchall()
                 cur.close()

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -652,7 +652,7 @@ class BinLogStreamReader(object):
                     WHERE
                         table_schema = %s AND table_name = %s
                     """, (schema, table))
-                result = cur.fetchall()
+                result = sorted(cur.fetchall(), key=lambda x: x['ORDINAL_POSITION'])
                 cur.close()
 
                 return result


### PR DESCRIPTION
# Problem
We observed that the `Handler_read_rnd` was continually increasing whenever `__get_table_information` was called upon starting PyMyRepl. The reason was found to be the usage of the `ORDER BY` clause on a non-indexed column within the function.

# Solution
Since the table entries were empty, and `ORDER BY` was being used on a non-indexed column, this led to an increase in the `Handler_read_rnd`. As a remedy, we removed the `ORDER BY` clause from the SQL query and instead used Python's `sort()` method to sort the results. Since `ORDINAL_POSITION` is auto-incremental, this change will return the same sorted results as the original `ORDER BY` clause, without the associated performance penalty.

# Changes
Removed the `ORDER BY` clause from the SQL query within `__get_table_information`.
Implemented sorting using Python's `sort()` method based on `ORDINAL_POSITION`.

# Benefits
Reduces the overhead associated with using the `ORDER BY` clause on a non-indexed column.
Mitigates the increase in `Handler_read_rnd`, leading to improved performance.

Fixed: #445 