### PR TITLE
Avoid UnicodeDecodeError for non-utf8 QueryEvents

### DIFF
--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -324,8 +324,9 @@ class QueryEvent(BinLogEvent):
         self.schema = self.packet.read(self.schema_length)
         self.packet.advance(1)
 
-        self.query = self.packet.read(event_size - 13 - self.status_vars_length
-                                      - self.schema_length - 1).decode("utf-8")
+        query = self.packet.read(event_size - 13 - self.status_vars_length
+                                 - self.schema_length - 1)
+        self.query = query.decode("utf-8", errors='backslashreplace')
         #string[EOF]    query
 
     def _dump(self):

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -18,7 +18,7 @@ class PyMySQLReplicationTestCase(base):
     def ignoredEvents(self):
         return []
 
-    def setUp(self):
+    def setUp(self, charset="utf8"):
         # default
         self.database = {
             "host": os.environ.get("MYSQL_5_7") or "localhost",
@@ -26,7 +26,7 @@ class PyMySQLReplicationTestCase(base):
             "passwd": "",
             "port": 3306,
             "use_unicode": True,
-            "charset": "utf8",
+            "charset": charset,
             "db": "pymysqlreplication_test"
         }
 


### PR DESCRIPTION
Query strings in QueryEvents that appear in the binlog stream must not necessarily be utf-8 encoded, but the current implementation handles only utf-8.

This commit adds the `errors="backslashreplace"` kwarg to decode(), to avoid a runtime error and insert \xNN escape sequences for byte sequences that are not valid utf-8. It includes a test that generates a QueryEvent with latin-1 encoding, which fails without the fix.