### PR TITLE
Fix test_allowed_event_list in TestBasicBinLogStreamReader

### DIFF
--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -31,9 +31,9 @@ class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
         return [GtidEvent, PreviousGtidsEvent]
 
     def test_allowed_event_list(self):
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 23)
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 22)
-        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 22)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 24)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 23)
+        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 23)
         self.assertEqual(len(self.stream._allowed_event_list([RotateEvent], None, False)), 1)
 
     def test_read_query_event(self):


### PR DESCRIPTION
Correct the expected lengths of _allowed_event_list in test cases. 
The test previously expected lengths of 23, 22, and 22 for different scenarios. 
These have been fixed to 24, 23, and 23 respectively to align with recent changes in the codebase.
