### PR TITLE
Fix GitHub Actions Failure by Updating Test Code for PreviousGtidsEvent

### DIFF
--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -31,9 +31,9 @@ class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
         return [GtidEvent, PreviousGtidsEvent]
 
     def test_allowed_event_list(self):
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 23)
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 22)
-        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 22)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 24)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 23)
+        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 23)
         self.assertEqual(len(self.stream._allowed_event_list([RotateEvent], None, False)), 1)
 
     def test_read_query_event(self):


### PR DESCRIPTION
[PreviousGtidsEvent was recently added to the codebase](https://github.com/julien-duponchelle/python-mysql-replication/commit/19fe16c572d184089a13b65e891c59c5f948968d), but the corresponding test cases in the TestBasicBinLogStreamReader class were not updated. This has been causing GitHub Actions to fail.

This PR fixes the issue by updating the test_allowed_event_list method in TestBasicBinLogStreamReader to include the correct expected lengths for _allowed_event_list.

Before the fix, the test expected lengths of 23, 22, and 22 for different scenarios. These have been corrected to 24, 23, and 23, respectively, to align with the addition of PreviousGtidsEvent.