### PR TITLE
Incorrect Parsing of Extra Data(NDB info) in Rows Event

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -62,7 +62,7 @@ class RowsEvent(BinLogEvent):
 
                     # ndb information
                     if self.extra_data_type == 0:
-                        self.nbd_info_length, self.nbd_info_format = struct.unpack('<BB', self.packet.read(1))
+                        self.nbd_info_length, self.nbd_info_format = struct.unpack('<BB', self.packet.read(2))
                         self.nbd_info = self.packet.read(self.nbd_info_length - 2)
                     # partition information
                     elif self.extra_data_type == 1:


### PR DESCRIPTION

The following is the code for parsing rows events within the Rows Event. It was observed that the `nbd_info_length` and `nbd_info_format` should each be read as 1-byte values, so they need to be modified to `self.packet.read(2)`.
* as-is
https://github.com/julien-duponchelle/python-mysql-replication/blob/c977dd8dde132acad23511369787bf040f40294b/pymysqlreplication/row_event.py#L65

- The table below is derived from comments in the [MySQL source code](https://github.com/mysql/mysql-server/blob/beb865a960b9a8a16cf999c323e46c5b0c67f21f/libbinlogevents/include/rows_event.h#L772-L814), describing the format of extra data (NDB info):
    
    ```bash

     	+----------+--------------------------------------+
            |type_code |        extra_row_ndb_info            |
            +--- ------+--------------------------------------+
            | NDB      |Len of ndb_info |Format |ndb_data     |
            | 1 byte   |1 byte          |1 byte |len - 2 byte |
            +----------+----------------+-------+-------------+
    ```