### PR TITLE
add py-mysql-elasticsearch-sync to readme, a project using pymyrepl

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Projects using this library
 * Aventri MySQL Monitor (https://github.com/aventri/mysql-monitor)
 * BitSwanPump: A real-time stream processor  (https://github.com/LibertyAces/BitSwanPump)
 * clickhouse-mysql-data-reader: https://github.com/Altinity/clickhouse-mysql-data-reader
+* py-mysql-elasticsearch-sync: https://github.com/jaehyeonpy/py-mysql-elasticsearch-sync
 
 MySQL server settings
 =========================


### PR DESCRIPTION
-  python-mysql-replication has its usage of 'MySQL to search engine replication', but there is only one usage that can be found in examples/logstash.
- The logstash thing is also a good usage, but I found it better to have more usage. So, I made py-mysql-elasticsearch-sync, which replicates mysql to elasticsearch using python-mysql-replication(https://github.com/jaehyeonpy/py-mysql-elasticsearch-sync).
- I would appreciate if you could merge this.