### PR TITLE
Remove duplicated Affected columns output in UpdateRowsEvent

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -602,7 +602,6 @@ class UpdateRowsEvent(RowsEvent):
 
     def _dump(self):
         super()._dump()
-        print("Affected columns: %d" % self.number_of_columns)
         print("Values:")
         for row in self.rows:
             print("--")


### PR DESCRIPTION
### Overview

This Pull Request aims to remove the duplicate "Affected columns" output in the `UpdateRowsEvent` class.

### Description

The `_dump()` method in both `RowsEvent` and `UpdateRowsEvent` classes includes a print statement for the number of affected columns. The duplicate output appears when using `UpdateRowsEvent`.

### Changes

- Removed the line `print("Affected columns: %d" % self.number_of_columns)` from the `_dump()` method in the `UpdateRowsEvent` class.

<img src="https://github.com/julien-duponchelle/python-mysql-replication/assets/47103479/db5b953b-09a1-44c6-b4ca-be28fac48df2" width="400">


Is there a specific reason for the duplicate "Affected columns" output? I'd appreciate any feedback on this.