### PR TITLE
Remove Python2 compatibility

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Python MySQL Replication documentation build configuration file, created by
 # sphinx-quickstart on Sun Sep 30 15:04:27 2012.
 #

--- a/examples/dump_events.py
+++ b/examples/dump_events.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 #
 # Dump all replication events from a remote mysql server

--- a/examples/logstash/mysql_to_logstash.py
+++ b/examples/logstash/mysql_to_logstash.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 #
 # Output logstash events to the console from MySQL replication stream

--- a/examples/redis_cache.py
+++ b/examples/redis_cache.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 #
 # Update a redis server cache when an evenement is trigger

--- a/pymysqlreplication/_compat.py
+++ b/pymysqlreplication/_compat.py
@@ -1,1 +1,0 @@
-text_type = str

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import struct
 import logging
 from distutils.version import LooseVersion

--- a/pymysqlreplication/bitmap.py
+++ b/pymysqlreplication/bitmap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 bitCountInByte = [
     0,
     1,

--- a/pymysqlreplication/column.py
+++ b/pymysqlreplication/column.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import struct
 
 from .constants import FIELD_TYPE

--- a/pymysqlreplication/constants/BINLOG.py
+++ b/pymysqlreplication/constants/BINLOG.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 UNKNOWN_EVENT = 0x00
 START_EVENT_V3 = 0x01
 QUERY_EVENT = 0x02

--- a/pymysqlreplication/constants/FIELD_TYPE.py
+++ b/pymysqlreplication/constants/FIELD_TYPE.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Original code from PyMySQL
 # Copyright (c) 2010 PyMySQL contributors
 #

--- a/pymysqlreplication/constants/__init__.py
+++ b/pymysqlreplication/constants/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .BINLOG import *
 from .FIELD_TYPE import *
 from .STATUS_VAR_KEY import *

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import binascii
 import struct
 import datetime

--- a/pymysqlreplication/gtid.py
+++ b/pymysqlreplication/gtid.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 import struct
 import binascii

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import struct
 
 from pymysqlreplication import constants, event, row_event

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import struct
 import decimal
 import datetime

--- a/pymysqlreplication/table.py
+++ b/pymysqlreplication/table.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 class Table(object):
     def __init__(
         self, table_id, schema, table, columns, primary_key=None, column_name_flag=False

--- a/pymysqlreplication/tests/__init__.py
+++ b/pymysqlreplication/tests/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from pymysqlreplication.tests.test_basic import *
 from pymysqlreplication.tests.test_data_type import *
 from pymysqlreplication.tests.test_data_objects import *

--- a/pymysqlreplication/tests/__init__.py
+++ b/pymysqlreplication/tests/__init__.py
@@ -1,10 +1,7 @@
 from pymysqlreplication.tests.test_basic import *
 from pymysqlreplication.tests.test_data_type import *
 from pymysqlreplication.tests.test_data_objects import *
+import unittest
 
 if __name__ == "__main__":
-    if sys.version_info < (2, 7):
-        import unittest2 as unittest
-    else:
-        import unittest
     unittest.main()

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -2,7 +2,6 @@ import pymysql
 import copy
 from pymysqlreplication import BinLogStreamReader
 import os
-import sys
 import unittest
 
 base = unittest.TestCase

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pymysql
 import copy
 from pymysqlreplication import BinLogStreamReader

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -3,11 +3,7 @@ import copy
 from pymysqlreplication import BinLogStreamReader
 import os
 import sys
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 base = unittest.TestCase
 

--- a/pymysqlreplication/tests/benchmark.py
+++ b/pymysqlreplication/tests/benchmark.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # This is a sample script in order to make benchmark
 # on library speed.
 #

--- a/pymysqlreplication/tests/test_abnormal.py
+++ b/pymysqlreplication/tests/test_abnormal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Test abnormal conditions, such as caused by a MySQL crash
 """
 import os.path

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -3,13 +3,8 @@ import io
 import os
 import sys
 import time
-
 import pymysql
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from pymysqlreplication.tests import base
 from pymysqlreplication import BinLogStreamReader

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import copy
 import io
 import os

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1,7 +1,6 @@
 import copy
 import io
 import os
-import sys
 import time
 import pymysql
 import unittest

--- a/pymysqlreplication/tests/test_data_objects.py
+++ b/pymysqlreplication/tests/test_data_objects.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 from pymysqlreplication.column import Column
 from pymysqlreplication.table import Table

--- a/pymysqlreplication/tests/test_data_objects.py
+++ b/pymysqlreplication/tests/test_data_objects.py
@@ -1,10 +1,5 @@
 import sys
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
+import unittest
 from pymysqlreplication.column import Column
 from pymysqlreplication.table import Table
 from pymysqlreplication.event import GtidEvent

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -1,6 +1,5 @@
 import copy
 import platform
-import sys
 import json
 from pymysqlreplication import BinLogStreamReader
 import unittest

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -18,15 +18,13 @@ from pymysqlreplication.tests import base
 from pymysqlreplication.constants.BINLOG import *
 from pymysqlreplication.row_event import *
 from pymysqlreplication.event import *
-from pymysqlreplication._compat import text_type
-
 
 __all__ = ["TestDataType"]
 
 
 def to_binary_dict(d):
     def encode_value(v):
-        if isinstance(v, text_type):
+        if isinstance(v, str):
             return v.encode()
         if isinstance(v, list):
             return [encode_value(x) for x in v]

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import copy
 import platform
 import sys

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -2,13 +2,8 @@ import copy
 import platform
 import sys
 import json
-
 from pymysqlreplication import BinLogStreamReader
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from decimal import Decimal
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 try:
     from setuptools import setup, Command


### PR DESCRIPTION
In this PR, we have removed the compatibility with Python 2 to streamline the code and leverage the features of Python 3 more fully. The specific changes include the following:

- Removed `# -*- coding: utf-8 -*-` from the top of Python files, as Python 3 assumes UTF-8 encoding by default.
- Eliminated conditional imports that checked `sys.version_info` to import different modules or packages based on the Python version.
- Deleted `_compat.py` file which was used to handle string type differences between Python 2 and 3.
  
#### Changes

1. **Removal of UTF-8 encoding declarations**
   
   Python 3 assumes UTF-8 encoding by default, so it's safe to remove `# -*- coding: utf-8 -*-` declarations from all files.

2. **Unification of imports**

   Removed conditional imports that were dependent on the Python version. Now, all imports are unified to be compatible with Python 3.

   For instance, the following conditional import:

   ```python
   if sys.version_info < (2, 7):
       import unittest2 as unittest
   else:
       import unittest
   ```

   Has been updated to simply:

   ```python
   import unittest
   ```

3. **Deletion of `_compat.py`**

   We removed the `_compat.py` file, which was primarily used to handle string type differences between Python 2 and 3. With this change, we are standardizing on the Python 3 string type.