### PR TITLE
bug hot-fix optional_meta_data_flag missing

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -567,6 +567,8 @@ class BinLogStreamReader(object):
                        By Applying this, provide properly mapped column information on UPDATE,DELETE,INSERT. 
                         """,
                 )
+            else:
+                self.__optional_meta_data = True
 
     def fetchone(self):
         while True:

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1696,7 +1696,7 @@ class TestOptionalMetaData(base.PyMySQLReplicationVersion8TestCase):
 
         event = self.stream.fetchone()
         self.assertIsInstance(event, TableMapEvent)
-        self.assertEqual(event.table_obj.data["columns"][0].name, None)
+        self.assertEqual(event.table_obj.data["columns"][0].name, "name")
         self.assertEqual(len(column_schemas), 0)
 
     def test_sync_column_drop_event_table_schema(self):
@@ -1727,9 +1727,9 @@ class TestOptionalMetaData(base.PyMySQLReplicationVersion8TestCase):
         self.assertEqual(len(event.table_obj.data["columns"]), 3)
         self.assertEqual(column_schemas[0][0], "drop_column1")
         self.assertEqual(column_schemas[1][0], "drop_column3")
-        self.assertEqual(event.table_obj.data["columns"][0].name, None)
-        self.assertEqual(event.table_obj.data["columns"][1].name, None)
-        self.assertEqual(event.table_obj.data["columns"][2].name, None)
+        self.assertEqual(event.table_obj.data["columns"][0].name, "drop_column1")
+        self.assertEqual(event.table_obj.data["columns"][1].name, "drop_column2")
+        self.assertEqual(event.table_obj.data["columns"][2].name, "drop_column3")
 
     def tearDown(self):
         self.execute("SET GLOBAL binlog_row_metadata='MINIMAL';")


### PR DESCRIPTION
I'm missing something while merging a conflicted branch.
https://github.com/julien-duponchelle/python-mysql-replication/pull/477

