### PR TITLE
fix last order column only when DML

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -119,7 +119,13 @@ class RowsEvent(BinLogEvent):
             column = self.columns[i]
             name = self.table_map[self.table_id].columns[i].name
             unsigned = self.table_map[self.table_id].columns[i].unsigned
-
+            if not name:
+                # If you are using mysql 5.7 or mysql 8, but binlog_row_metadata = "MINIMAL",
+                # we do not know the column information.
+                # If you know column information,
+                # mysql 5.7 version Users Use Under 1.0 version
+                # mysql 8.0 version Users Set binlog_row_metadata = "FULL"
+                name = "UNKNOWN_COL" + str(i)
             values[name] = self.__read_values_name(
                 column,
                 null_bitmap,


### PR DESCRIPTION
resolve #510 

Description
----
Over  pymyrepli 1.0 version 
We got column Information from optional metadata

BUT If Mysql 5.7 Users use over 1.0 version They do not get Column Information.
Mysql 5.7 version does not have binlog_row_metadata variable. so we support 0.45.1 version for mysql 5.7 version

Nevertheless If Mysql 5.7 version use over 1.0 Version, users found only last order column Values.

When we do not know column Information values dictionary key is always null, So overwrite value Object.
```
values[name] = self.__read_values_name(
          column,
          null_bitmap,
          null_bitmap_index,
          cols_bitmap,
          unsigned,
          i,
      )
```

Solution
----
To avoid user confusion, it is marked and displayed as UNKNOWN_COL.
