### PR TITLE
f-string 포매팅 적용: pymysqlreplication/binlogstream.py#354-355

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -351,8 +351,7 @@ class BinLogStreamReader(object):
         if self.slave_uuid:
             cur = self._stream_connection.cursor()
             cur.execute(
-                "SET @slave_uuid = %s, @replica_uuid = %s",
-                (self.slave_uuid, self.slave_uuid),
+                f"SET @slave_uuid = {self.slave_uuid}, @replica_uuid = {self.slave_uuid}"
             )
             cur.close()
 


### PR DESCRIPTION
문자열 포매팅 되어 있던 부분을 f-string 포매팅으로 변경하였습니다.

close #535 