### PR TITLE
refactor: check 'is_mariadb' when trying to set 'mariadb-related variable(mariadb_slave_capability)' to master

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -374,9 +374,10 @@ class BinLogStreamReader(object):
         # Mariadb, when it tries to replace GTID events with dummy ones. Given that this library understands GTID
         # events, setting the capability to 4 circumvents this error.
         # If the DB is mysql, this won't have any effect so no need to run this in a condition
-        cur = self._stream_connection.cursor()
-        cur.execute("SET @mariadb_slave_capability=4")
-        cur.close()
+        if(self.is_mariadb):
+            cur = self._stream_connection.cursor()
+            cur.execute("SET @mariadb_slave_capability=4")
+            cur.close()
 
         self._register_slave()
 


### PR DESCRIPTION
thought codes below needs check whether the master is mariaDB or not.
## before
<img width="464" alt="Screen Shot 2023-10-16 at 11 56 35 PM" src="https://github.com/julien-duponchelle/python-mysql-replication/assets/108053947/0a4f144c-1f86-4634-9b44-8616a036bce1">

## after
<img width="443" alt="Screen Shot 2023-10-16 at 11 56 07 PM" src="https://github.com/julien-duponchelle/python-mysql-replication/assets/108053947/f7ff8dae-5015-49ce-ae86-d6aab0426746">
