### PR TITLE
Add error logging for crc32 validation failures.

### DIFF
--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -58,10 +58,8 @@ class BinLogEvent(object):
         data = self.packet.read(19 + self.event_size)
         footer = self.packet.read(4)
         byte_data = zlib.crc32(data).to_bytes(4, byteorder="little")
-        if byte_data == footer:
-            self._is_event_valid = True
-        else:
-            self._is_event_valid = False
+        self._is_event_valid = True if byte_data == footer else False
+        if not self._is_event_valid:
             logging.error(
                 f"An CRC32 has failed for the event type {self.event_type}, "
                 "indicating a potential integrity issue with the data."


### PR DESCRIPTION
### Description

This PR add logging for situations where CRC32 validation does not pass.

By monitoring these failures, we can ensure data integrity throughout the application.