### PR TITLE
Add omitted charset setting in base.py

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   workflow_dispatch:
 env:
-  PYTEST_SKIP_OPTION: "not test_no_trailing_rotate_event and not test_end_log_pos and not test_query_event_latin1"
+  PYTEST_SKIP_OPTION: "not test_no_trailing_rotate_event and not test_end_log_pos"
 jobs:
   test:
     strategy:

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -51,6 +51,7 @@ class PyMySQLReplicationTestCase(base):
         self.execute("DROP DATABASE IF EXISTS pymysqlreplication_test")
         self.execute("CREATE DATABASE pymysqlreplication_test")
         db = copy.copy(self.database)
+        db["charset"] = charset
         self.connect_conn_control(db)
         self.stream = None
         self.resetBinLog()


### PR DESCRIPTION
### Description

This pull request addresses [Issue #564](https://github.com/julien-duponchelle/python-mysql-replication/issues/564).

To resolve the failing TestLatin1 test, I have added the line `db["charset"] = charset` to base.py.

As a result of this change, the charset setting now functions correctly in the TestLatin1 test.

https://github.com/julien-duponchelle/python-mysql-replication/blob/1d2c8aba5d96ca4573054e51038d9f62b43da9e9/pymysqlreplication/tests/test_basic.py#L1474-L1476


With this fix in place, I have also re-included the test_query_event_latin1 test in the pytest suite, as it now passes successfully.