### PR TITLE
Remove duplicate img tag for project logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 python-mysql-replication
 ========================
 
-<a href="https://pypi.python.org/pypi/mysql-replication"><img src="http://img.shields.io/pypi/dm/mysql-replication.svg"></a>
+<a href="https://pypi.python.org/pypi/mysql-replication"><img src="https://github.com/julien-duponchelle/python-mysql-replication/blob/main/logo.svg"></a>
 
-<img src ="https://github.com/julien-duponchelle/python-mysql-replication/blob/main/logo.svg">
 Pure Python Implementation of MySQL replication protocol build on top of PyMYSQL. This allows you to receive event like insert, update, delete with their datas and raw SQL queries.
 
 Use cases


### PR DESCRIPTION
There were two duplicate image tags for project logo.
One of 2 didn't even show any image.
Removed invalid image tag.