### PR TITLE
fake rotate event check

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -596,6 +596,11 @@ class BinLogStreamReader(object):
                 if code in MYSQL_EXPECTED_ERROR_CODES:
                     self._stream_connection.close()
                     self.__connected_stream = False
+                    logging.WARN(
+                        """
+                          A pymysql.OperationalError error occurred, Re-request the connection.
+                        """
+                    )
                     continue
                 raise
 
@@ -635,7 +640,9 @@ class BinLogStreamReader(object):
                 # invalidates all our cached table id to schema mappings. This means we have to load them all
                 # again for each logfile which is potentially wasted effort but we can't really do much better
                 # without being broken in restart case
-                self.table_map = {}
+                if binlog_event.timestamp != 0:
+                    self.table_map = {}
+
             elif binlog_event.log_pos:
                 self.log_pos = binlog_event.log_pos
 

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -1,4 +1,3 @@
-import logging
 import struct
 import decimal
 import datetime
@@ -36,12 +35,6 @@ class RowsEvent(BinLogEvent):
             self.table = self.table_map[self.table_id].table
         except KeyError:  # If we have filter the corresponding TableMap Event
             self._processed = False
-            logging.log(
-                logging.WARN,
-                """
-                  A pymysql.OperationalError error occurred, causing a fake rotate event and initialization of the table_map
-                """,
-            )
             return
 
         if self.__only_tables is not None and self.table not in self.__only_tables:


### PR DESCRIPTION
### Description
resolve #578 

We initialize the table_map when we create the binlogstreamreader object.

After that, if the binlog is maxsize full, a rotateEvent is fired.
At that point, we empty the table_map because the timestamp is not zero.
Then, when we connect to the next binlogfile, we get a rotateEvent with a timestamp of 0. We don't need to empty the table_map again.

However, when we disconnect from mysql and reconnect, we get a fake rotateEvent with a 0 timestamp.
In this case, we inform the client of error logging and do not initialize the table map.


### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify below)

### Checklist
- [x] I have read and understood the [CONTRIBUTING.md](https://github.com/julien-duponchelle/python-mysql-replication/blob/main/CONTRIBUTING.md) document.
- [x] I have checked there aren't any other open [Pull Requests](https://github.com/julien-duponchelle/python-mysql-replication/pulls) for the desired changes.
- [ ] This PR resolves an issue #[Issue Number Here].

### Tests
- [x] All tests have passed.
- [x] New tests have been added to cover the changes. (describe below if applicable).

### Additional Information
<!--If there's any additional information or context you'd like to provide for this PR, such as screenshots, reference documents, or release notes, please include them here.-->

