### PR TITLE
Fix an issue in parsing default column charset

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -1005,14 +1005,17 @@ class TableMapEvent(BinLogEvent):
         column_type_detect_function,
     ):
         column_charset = []
+        position = 0
         for i in range(self.column_count):
             column_type = self.columns[i].type
             if not column_type_detect_function(column_type, dbms=self.dbms):
                 continue
-            elif i not in column_charset_collation.keys():
-                column_charset.append(default_charset_collation)
             else:
-                column_charset.append(column_charset_collation[i])
+                if position not in column_charset_collation.keys():
+                    column_charset.append(default_charset_collation)
+                else:
+                    column_charset.append(column_charset_collation[position])
+                position += 1
 
         return column_charset
 


### PR DESCRIPTION
  ### Description
  When parsing the default charset optional metadata, when handling the column index/collation number pairs, the column index is in the range of the number of columns with charset (not the number of all the columns).
  Like how it's done here: https://github.com/ClickHouse/ClickHouse/blob/001b67863a57c4d734d94e375e6fdeb4a9407951/src/Core/MySQL/MySQLReplication.cpp#L353
  
  ### Type of Change
  - [x] Bug fix
  
  ### Checklist
  - [x] I have read and understood the [CONTRIBUTING.md](https://github.com/julien-duponchelle/python-mysql-replication/blob/main/CONTRIBUTING.md) document.
  - [x] I have checked there aren't any other open [Pull Requests](https://github.com/julien-duponchelle/python-mysql-replication/pulls) for the desired changes.
  - [x] This PR resolves an issue #[334](https://github.com/julien-duponchelle/python-mysql-replication/issues/334).
  
  ### Tests
  - [x] All tests have passed.
  - [x] New tests have been added to cover the changes. (describe below if applicable).


