### PR TITLE
Fix missing dependency on `packaging`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,8 @@ setup(
         "pymysqlreplication.util",
     ],
     cmdclass={"test": TestCommand},
-    install_requires=["pymysql>=1.1.0"],
+    install_requires=[
+        "packaging",
+        "pymysql>=1.1.0",
+    ],
 )


### PR DESCRIPTION
### Description

Since the deprecation of `distutils` (#574), the [`packaging`](https://pypi.org/project/packaging/) package has become a requirement, but was missing from the project’s dependencies.

We noticed this when recently attempting to install [pg_chameleon](https://pgchameleon.org/about/), only to end up facing a `ModuleNotFoundError`, which we traced back to this unsatisfied dependency.

The present Pull Request fixes this by explicitly listing `packaging` as a dependency.

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify below)

### Checklist
- [X] I have read and understood the [CONTRIBUTING.md](https://github.com/julien-duponchelle/python-mysql-replication/blob/main/CONTRIBUTING.md) document.
- [X] I have checked there aren't any other open [Pull Requests](https://github.com/julien-duponchelle/python-mysql-replication/pulls) for the desired changes.
- [ ] This PR resolves an issue #[Issue Number Here].

### Tests
- [ ] All tests have passed.
- [ ] New tests have been added to cover the changes. (describe below if applicable).