### PR TITLE
test dump method in test_delete_row_event

### DIFF
--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -299,8 +299,8 @@ class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
         event._dump()
         output = mock_stdout.getvalue()
         self.assertIn("Values:", output)
-        self.assertIn("* id : 1", output)
-        self.assertIn("* data : Hello World", output)
+        self.assertIn("* UNKNOWN_COL0 : 1", output)
+        self.assertIn("* UNKNOWN_COL1 : Hello World", output)
 
     def test_update_row_event(self):
         query = "CREATE TABLE test (id INT NOT NULL AUTO_INCREMENT, data VARCHAR (50) NOT NULL, PRIMARY KEY (id))"


### PR DESCRIPTION
### Description
<!--Please describe your pull request as detailed as possible. Include information on what problem it solves, what features it adds, etc.-->

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other (add test dump method)

### Checklist
- [x] I have read and understood the [CONTRIBUTING.md](https://github.com/julien-duponchelle/python-mysql-replication/blob/main/CONTRIBUTING.md) document.
- [x] I have checked there aren't any other open [Pull Requests](https://github.com/julien-duponchelle/python-mysql-replication/pulls) for the desired changes.
- [ ] This PR resolves an issue #[Issue Number Here].

### Tests
- [x] All tests have passed.
- [x] New tests have been added to cover the changes. (describe below if applicable).

### Additional Information
<!--If there's any additional information or context you'd like to provide for this PR, such as screenshots, reference documents, or release notes, please include them here.-->

