### PR TITLE
Fix parsing of query field of RowsQueryEvent

### DIFF
--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -880,12 +880,11 @@ class RowsQueryLogEvent(BinLogEvent):
         super(RowsQueryLogEvent, self).__init__(
             from_packet, event_size, table_map, ctl_connection, **kwargs
         )
-        self.query_length = self.packet.read_uint8()
-        self.query = self.packet.read(self.query_length).decode("utf-8")
+        self.packet.advance(1)
+        self.query = self.packet.read_available().decode("utf-8")
 
     def dump(self):
         print(f"=== {self.__class__.__name__} ===")
-        print(f"Query length: {self.query_length}")
         print(f"Query: {self.query}")
 
 

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -1,6 +1,7 @@
 from pymysqlreplication import constants, event, row_event
 from pymysqlreplication.json_binary import parse_json, JsonDiff, JsonDiffOperation
 from pymysqlreplication.util.bytes import *
+from pymysqlreplication.constants import BINLOG
 
 # Constants from PyMYSQL source code
 NULL_COLUMN = 251
@@ -384,3 +385,6 @@ class BinLogPacketWrapper(object):
 
     def bytes_to_read(self):
         return len(self.packet._data) - self.packet._position
+
+    def read_available(self):
+        return self.packet.read(self.bytes_to_read() - BINLOG.BINLOG_CHECKSUM_LEN)


### PR DESCRIPTION
### Description
The first byte of payload in RowsQueryEvent must be ignored without being used as the length for the following field `query`. Yet, the existing code did use this value as length for `query` and  fails whenever parsing query longer than 255 characters. 

I fixed the bug referring to 
[code from msql-server](https://github.com/mysql/mysql-server/blob/dee24346f205e1907e2086e8a8684e77b6e292fe/libs/mysql/binlog/event/rows_event.cpp#L537-L543).

Other clients in different languages implement the RowsQueryEvent the way mysql-server does and noted below as references.

[MysqlCdc (c#)](https://github.com/HongGeonUi/MySqlCdc/blob/45328aa819d8975054d632217cad5c375b1d13d1/src/MySqlCdc/Providers/MySql/Parsers/RowsQueryEventParser.cs#L18)
[mysql-binlog-connector-java (java)](https://github.com/osheroff/mysql-binlog-connector-java/blob/f6b853ba62faad5ff59d6aa09856761878484eb1/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/RowsQueryEventDataDeserializer.java#L31)

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify below)

### Checklist
- [x] I have read and understood the [CONTRIBUTING.md](https://github.com/julien-duponchelle/python-mysql-replication/blob/main/CONTRIBUTING.md) document.
- [x] I have checked there aren't any other open [Pull Requests](https://github.com/julien-duponchelle/python-mysql-replication/pulls) for the desired changes.
- [x] This PR resolves an issue #601.

### Tests
- [x] All tests have passed.
- [x] New tests have been added to cover the changes. (describe below if applicable).

### Additional Information
<!--If there's any additional information or context you'd like to provide for this PR, such as screenshots, reference documents, or release notes, please include them here.-->

