### PR TITLE
fix log statement for BinLogStreamReader.fetchone

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -603,7 +603,7 @@ class BinLogStreamReader(object):
                         logging.WARN,
                         """
                           A pymysql.OperationalError error occurred, Re-request the connection.
-                        """
+                        """,
                     )
                     continue
                 raise

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -688,9 +688,9 @@ class BinLogStreamReader(object):
                 binlog_event.event_type == TABLE_MAP_EVENT
                 and binlog_event.event is not None
             ):
-                self.table_map[
-                    binlog_event.event.table_id
-                ] = binlog_event.event.get_table()
+                self.table_map[binlog_event.event.table_id] = (
+                    binlog_event.event.get_table()
+                )
 
             # event is none if we have filter it on packet level
             # we filter also not allowed events

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -599,7 +599,8 @@ class BinLogStreamReader(object):
                 if code in MYSQL_EXPECTED_ERROR_CODES:
                     self._stream_connection.close()
                     self.__connected_stream = False
-                    logging.WARN(
+                    logging.log(
+                        logging.WARN,
                         """
                           A pymysql.OperationalError error occurred, Re-request the connection.
                         """

--- a/pymysqlreplication/tests/binlogfilereader.py
+++ b/pymysqlreplication/tests/binlogfilereader.py
@@ -1,4 +1,5 @@
 """Read binlog files"""
+
 import struct
 
 from pymysqlreplication import constants

--- a/pymysqlreplication/tests/test_abnormal.py
+++ b/pymysqlreplication/tests/test_abnormal.py
@@ -1,5 +1,6 @@
 """Test abnormal conditions, such as caused by a MySQL crash
 """
+
 import os.path
 
 from pymysqlreplication.tests import base


### PR DESCRIPTION
### Description
<!--Please describe your pull request as detailed as possible. Include information on what problem it solves, what features it adds, etc.-->
This PR fix the log statement in `BinLogStreamReader.fetchone` using `logging.WARN`, which triggers an exception.
I've copied the same logic as the logging statement above, using `logging.log(logging.WARN, <statement>)` to fix this issue.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify below)

### Checklist
- [x] I have read and understood the [CONTRIBUTING.md](https://github.com/julien-duponchelle/python-mysql-replication/blob/main/CONTRIBUTING.md) document.
- [x] I have checked there aren't any other open [Pull Requests](https://github.com/julien-duponchelle/python-mysql-replication/pulls) for the desired changes.
- [x] This PR resolves an issue #607.

### Tests
- [ ] All tests have passed.
- [ ] New tests have been added to cover the changes. (describe below if applicable).

### Additional Information
<!--If there's any additional information or context you'd like to provide for this PR, such as screenshots, reference documents, or release notes, please include them here.-->

