### PR TITLE
Add sb-osc to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Projects using this library
 * clickhouse-mysql-data-reader: https://github.com/Altinity/clickhouse-mysql-data-reader
 * py-mysql-elasticsearch-sync: https://github.com/jaehyeonpy/py-mysql-elasticsearch-sync
 * synch: Sync data from other DB to ClickHouse (https://github.com/long2ice/synch)
+* sb-osc: Online schema change tool created by Sendbird (https://github.com/sendbird/sb-osc)
 
 MySQL server settings
 =========================


### PR DESCRIPTION
### Description
<!--Please describe your pull request as detailed as possible. Include information on what problem it solves, what features it adds, etc.-->
We recently released a new online schema change tool `sb-osc` as an open source. It uses `python-mysql-replication` for capturing DML events from database, so we'd like to add this to the list in README
cc. @dongwook-chan 

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please specify below)

### Checklist
- [x] I have read and understood the [CONTRIBUTING.md](https://github.com/julien-duponchelle/python-mysql-replication/blob/main/CONTRIBUTING.md) document.
- [x] I have checked there aren't any other open [Pull Requests](https://github.com/julien-duponchelle/python-mysql-replication/pulls) for the desired changes.
- [ ] This PR resolves an issue #[Issue Number Here].

### Tests
- [ ] All tests have passed.
- [ ] New tests have been added to cover the changes. (describe below if applicable).

### Additional Information
<!--If there's any additional information or context you'd like to provide for this PR, such as screenshots, reference documents, or release notes, please include them here.-->
[SB-OSC blog](https://sendbird.com/blog/sb-osc-sendbird-online-schema-change)
