### PR TITLE
Bug fix: typo in ident variable name

### DIFF
--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -459,7 +459,7 @@ class HeartbeatLogEvent(BinLogEvent):
 
     def _dump(self):
         super()._dump()
-        print(f"Current binlog: {self.indent}")
+        print(f"Current binlog: {self.ident}")
 
 
 class QueryEvent(BinLogEvent):


### PR DESCRIPTION
### Description
The `HeartbeatLogEvent::dump` method had a typo in the `ident` var name (`indent` was used instead). This caused a crash when dumping out heartbeat events. 

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify below)

### Checklist
- [X] I have read and understood the [CONTRIBUTING.md](https://github.com/julien-duponchelle/python-mysql-replication/blob/main/CONTRIBUTING.md) document.
- [X] I have checked there aren't any other open [Pull Requests](https://github.com/julien-duponchelle/python-mysql-replication/pulls) for the desired changes.
- [ ] This PR resolves an issue #[Issue Number Here].

### Tests
- [X] All tests have passed.
- [ ] New tests have been added to cover the changes. (describe below if applicable).

### Additional Information
I tested this change manually, but haven't added tests yet. Feel free to suggest a good spot for this test and I'll be happy to take another pass.
