### PR TITLE
Fixing an issue of initializing table map when fake rotate event catching for Mysql versions 5.5, 5.6, 5.7

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -554,7 +554,8 @@ class BinLogStreamReader(object):
                 # invalidates all our cached table id to schema mappings. This means we have to load them all
                 # again for each logfile which is potentially wasted effort but we can't really do much better
                 # without being broken in restart case
-                self.table_map = {}
+                if binlog_event.timestamp != 0:
+                    self.table_map = {}
             elif binlog_event.log_pos:
                 self.log_pos = binlog_event.log_pos
 


### PR DESCRIPTION
### Description
Fixed the same issue as PR [579](https://github.com/julien-duponchelle/python-mysql-replication/pull/579) did, adding a fix for Mysql versions 5.5, 5.6, 5.7
Resolve issue [578](https://github.com/julien-duponchelle/python-mysql-replication/issues/578) for Mysql versions 5.5, 5.6, 5.7

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify below)

### Checklist
- [X] I have read and understood the [CONTRIBUTING.md](https://github.com/julien-duponchelle/python-mysql-replication/blob/main/CONTRIBUTING.md) document.
- [X] I have checked there aren't any other open [Pull Requests](https://github.com/julien-duponchelle/python-mysql-replication/pulls) for the desired changes.
- [ ] This PR resolves an issue #[Issue Number Here].

### Tests
- [ ] All tests have passed.
- [ ] New tests have been added to cover the changes. (describe below if applicable).

### Additional Information
<!--If there's any additional information or context you'd like to provide for this PR, such as screenshots, reference documents, or release notes, please include them here.-->

