### PR TITLE
publish a wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,10 @@ jobs:
         pip install
         build
         --user
-    - name: Build a source tarball
+    - name: Build distributions
       run: >-
         python3 -m
         build
-        --sdist
         --outdir dist/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
publish a wheel

All installation in python is from wheel.  If maintainers do not publish wheels, then every user install has to build the wheel.  That has several small disadvantages - it is slower, it can go wrong, some users will not want arbitrary code execution at install time, etc.

The done thing - even for a pure python package - is to publish both a source distribution and a wheel