### PR TITLE
Use project logger instead of the root logger

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -1,8 +1,7 @@
 import struct
-import logging
 from packaging.version import Version
 
-logger = logging.getLogger(__name__)
+from .logger import logger
 
 import pymysql
 from pymysql.constants.COMMAND import COM_BINLOG_DUMP, COM_REGISTER_SLAVE

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -3,11 +3,11 @@ import struct
 import datetime
 import decimal
 import zlib
-import logging
 
 from pymysqlreplication.constants.STATUS_VAR_KEY import *
 from pymysqlreplication.exceptions import StatusVariableMismatch
 from pymysqlreplication.util.bytes import parse_decimal_from_bytes
+from pymysqlreplication.logger import logger
 from typing import Union, Optional
 import json
 
@@ -64,7 +64,7 @@ class BinLogEvent(object):
         byte_data = zlib.crc32(data).to_bytes(4, byteorder="little")
         self._is_event_valid = True if byte_data == footer else False
         if not self._is_event_valid:
-            logging.error(
+            logger.error(
                 f"An CRC32 has failed for the event type {self.event_type}, "
                 "indicating a potential integrity issue with the data."
             )

--- a/pymysqlreplication/logger.py
+++ b/pymysqlreplication/logger.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger(__name__.split('.')[0])

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -1,12 +1,12 @@
 import struct
 import decimal
 import datetime
-import logging
 
 from pymysql.charset import charset_by_name
 from enum import Enum
 
 from .event import BinLogEvent
+from .logger import logger
 from .constants import FIELD_TYPE
 from .constants import BINLOG
 from .constants import CHARSET
@@ -958,12 +958,12 @@ class TableMapEvent(BinLogEvent):
             _COLUMN_NAME_CACHE[cache_key] = column_names
 
             if self.__enable_logging and column_names:
-                logging.info(f"Cached column names for {cache_key}: {len(column_names)} columns")
+                logger.info(f"Cached column names for {cache_key}: {len(column_names)} columns")
 
             return column_names
         except Exception as e:
             if self.__enable_logging:
-                logging.warning(f"Failed to fetch column names for {cache_key}: {type(e).__name__}: {e}")
+                logger.warning(f"Failed to fetch column names for {cache_key}: {type(e).__name__}: {e}")
             # Cache empty result to avoid retry spam
             _COLUMN_NAME_CACHE[cache_key] = []
             return []


### PR DESCRIPTION
### Description
<!--Please describe your pull request as detailed as possible. Include information on what problem it solves, what features it adds, etc.-->

moved logger to project logger to have a better, project-named logger name.
root logger is usually used by applications, not for library.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify below)

### Checklist
- [ ] I have read and understood the [CONTRIBUTING.md](https://github.com/julien-duponchelle/python-mysql-replication/blob/main/CONTRIBUTING.md) document.
- [x] I have checked there aren't any other open [Pull Requests](https://github.com/julien-duponchelle/python-mysql-replication/pulls) for the desired changes.
- [ ] This PR resolves an issue #[Issue Number Here].

### Tests
- [ ] All tests have passed.
- [ ] New tests have been added to cover the changes. (describe below if applicable).

### Additional Information
<!--If there's any additional information or context you'd like to provide for this PR, such as screenshots, reference documents, or release notes, please include them here.-->
