### PR TITLE
Fix MySQL 8.4+ binlog reset compatibility in tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install ruff==0.9.10
 
       - name: Run lint script
         run: bash scripts/lint.sh

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -155,7 +155,12 @@ class PyMySQLReplicationTestCase(base):
         return c
 
     def resetBinLog(self):
-        self.execute("RESET MASTER")
+        try:
+            self.execute("RESET BINARY LOGS AND GTIDS")
+        except pymysql.err.ProgrammingError as exc:
+            if not exc.args or exc.args[0] != 1064:
+                raise
+            self.execute("RESET MASTER")
         if self.stream is not None:
             self.stream.close()
         self.stream = BinLogStreamReader(

--- a/pymysqlreplication/tests/benchmark.py
+++ b/pymysqlreplication/tests/benchmark.py
@@ -53,7 +53,12 @@ execute(conn, "CREATE TABLE test (i INT) ENGINE = MEMORY")
 execute(conn, "INSERT INTO test VALUES(1)")
 execute(conn, "CREATE TABLE test2 (i INT) ENGINE = MEMORY")
 execute(conn, "INSERT INTO test2 VALUES(1)")
-execute(conn, "RESET MASTER")
+try:
+    execute(conn, "RESET BINARY LOGS AND GTIDS")
+except pymysql.err.ProgrammingError as exc:
+    if not exc.args or exc.args[0] != 1064:
+        raise
+    execute(conn, "RESET MASTER")
 
 
 if os.fork() != 0:

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1259,6 +1259,7 @@ class TestStatementConnectionSetting(base.PyMySQLReplicationTestCase):
         self.charset_num = 33
         if self.isMariaDB():
             self.charset_num = 8
+            self.execute("SET NAMES utf8 COLLATE utf8_general_ci")
         # if self.isMySQL80AndMore():
         #     self.charset_num = 255
 
@@ -1641,7 +1642,13 @@ class TestMariadbBinlogStreamReader2(base.PyMySQLReplicationTestCase):
         # 'mariadb gtid list event' of second binlog file
         event = self.stream.fetchone()
         self.assertEqual(event.event_type, 163)
-        self.assertEqual(event.gtid_list[0].gtid, "0-1-15")
+        server_id = self.execute("SELECT @@server_id").fetchone()[0]
+        gtid = event.gtid_list[0]
+        self.assertEqual(gtid.domain_id, 0)
+        self.assertEqual(gtid.server_id, server_id)
+        self.assertGreater(gtid.gtid_seq_no, 0)
+        self.assertLessEqual(gtid.gtid_seq_no, 15)
+        self.assertEqual(gtid.gtid, f"0-{server_id}-{gtid.gtid_seq_no}")
 
     def test_format_description_event(self):
         if not self.isMariaDB():
@@ -1660,7 +1667,7 @@ class TestMariadbBinlogStreamReader2(base.PyMySQLReplicationTestCase):
         self.assertIsInstance(event, FormatDescriptionEvent)
         self.assertIsInstance(event.binlog_version, tuple)
         self.assertIsInstance(event.mysql_version_str, str)
-        self.assertTrue(event.mysql_version_str.startswith("10."))
+        self.assertTrue(event.mysql_version_str.startswith(self.getMySQLVersion()))
         self.assertIsInstance(event.common_header_len, int)
         self.assertIsInstance(event.post_header_len, tuple)
         self.assertIsInstance(event.mysql_version, tuple)


### PR DESCRIPTION
## Summary

- try `RESET BINARY LOGS AND GTIDS` first and fall back to `RESET MASTER` only for syntax error 1064
- apply the same reset compatibility behavior to the benchmark script
- remove MariaDB major-version, collation, server-id, and binlog-rotation assumptions from integration tests
- pin CI Ruff to the same 0.9.10 release used by pre-commit, preventing unreviewed rule changes from breaking the whole repository

This is a follow-up to #627. The production binlog status fallback is already present, but the test setup still used `RESET MASTER`, which was removed in MySQL 8.4.

## Why capability detection

Trying the current statement and falling back on syntax error works across MySQL's old, current, and calendar-based version schemes, as well as MariaDB, without parsing vendor-specific version strings.

## Test results

The write-row integration test, including test setup and automatic binlog positioning, passed on:

- Percona Server for MySQL 5.7.44-48
- MySQL 8.0.46, 8.4.11, 9.7.2, and 26.7.0
- MariaDB 10.6.27, 10.11.18, 11.4.12, 11.8.8, and 12.2.2

Full suites:

- MySQL 8.4.11: 157 passed, 11 skipped, 2 deselected
- MariaDB 12.2.2: 127 passed, 41 skipped, 2 deselected

Static checks:

- `ruff==0.9.10 check pymysqlreplication`
- `git diff --check`
